### PR TITLE
Fixtures and config scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,18 +26,24 @@ We recommend using the provided Vagrant environment to develop and run tests.
 3. In the `edx-e2e-tests/vagrant` directory, execute this command:
 
 .. code:: bash
-    
+
     vagrant up
 
 4. This will create and provision a new Vagrant environment.
 
-You will also need an installation of the edX to run the tests on. 
+You will also need an installation of the edX to run the tests on.
 See `edx/configuration`__ for instructions on provisioning an edX instance.
 
 __ http://docs.vagrantup.com/v2/installation/index.html
 __ http://www.ansibleworks.com/docs/intro_installation.html
 __ https://github.com/edx/configuration
 
+
+Configuration
+-------------
+
+Edit the configuration file ``config.ini`` to provide information about the system under test.
+You can specify another configuration file by setting the ``CONFIG_PATH`` environment variable.
 
 
 Running Tests Locally
@@ -48,21 +54,19 @@ To run tests within the Vagrant environment:
 .. code:: bash
 
     cd /opt/dev/edx-e2e-tests
-    fab test_edxapp -H HOSTNAME
-
-where ``HOSTNAME`` is the hostname of the test environment.
+    fab test_edxapp
 
 You can run a specific test using nose-style test specifiers:
 
 .. code:: bash
 
-    fab test_edxapp:test_lms.py:LoggedOutTest.test_register -H HOSTNAME
+    fab test_edxapp:test_lms.py:LoggedOutTest.test_register
 
 By default, tests run locally in Firefox.  You can also use Chrome:
 
 .. code:: bash
 
-    SELENIUM_BROWSER=chrome fab test_edxapp -H HOSTNAME
+    SELENIUM_BROWSER=chrome fab test_edxapp
 
 
 
@@ -83,15 +87,15 @@ variables as the `Sauce OnDemand Plugin`__ for Jenkins
 3. In another terminal, run the tests:
 
 .. code:: bash
-    
+
     source /opt/dev/jenkins_env
-    fab test_edxapp -H HOSTNAME
+    fab test_edxapp
 
 To speed things up, you can also run tests in parallel:
 
 .. code:: bash
 
-    NUM_PARALLEL=4 fab test_edxapp -H HOSTNAME
+    NUM_PARALLEL=4 fab test_edxapp
 
 __ https://saucelabs.com/docs/connect
 __ https://wiki.jenkins-ci.org/display/JENKINS/Sauce+OnDemand+Plugin

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,9 @@
+[edxapp]
+protocol: http
+host: YOUR_SANDBOX_HOST
+ssh_keyfile: PATH_TO_SSH_PRIVATE_KEY
+ssh_user: YOUR_SANDBOX_USERNAME
+
+[mktg]
+protocol: http
+host: YOUR_SANDBOX_HOST

--- a/e2e_framework/web_app_fixture.py
+++ b/e2e_framework/web_app_fixture.py
@@ -1,0 +1,112 @@
+"""
+Specify test fixtures.  In this context, a "fixture" is a
+pre-condition for running a test.
+
+Examples:
+
+    * A user exists with a particular username and password.
+    * A file has been uploaded with a particular name.
+"""
+
+from abc import ABCMeta, abstractproperty, abstractmethod
+from fabric.api import execute, env
+from fabric.network import disconnect_all
+
+
+class WebAppFixtureError(Exception):
+    """
+    An error occurred while installing a test fixture.
+    """
+    pass
+
+
+class WebAppFixture(object):
+    """
+    Define a "fixture" (pre-condition) for running a test.
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def install(self):
+        """
+        Guarantee that the fixture conditions are satisfied.
+        Examples:
+
+            * Create a user with a particular name if the user does not already exist.
+            * Upload a file with a particular name if it does not already exist.
+
+        This operation needs to satisfy these conditions:
+
+            1) Synchronous: When execution completes, the state should be set.
+            2) Test-Independent: Should not interfere with the execution
+                of any test (including multiple runs of the same test)
+
+        Counter-examples:
+            * Clearing the database (may interfere with other tests)
+            * Changing a configuration setting (may interfere with other tests)
+            * Starting an import, but returning before it finishes (not synchronous)
+
+        One technique for ensuring test independence is to use
+        `WebAppTest.unique_id`.  For example, you might include
+        the unique id in the username to ensure each test
+        creates a unique user, thereby avoiding collisions between tests.
+
+        Another technique is to ensure that install operations are idempotent.
+        For example, if the fixture is "ensure this file is uploaded",
+        then upload the file only if it does not already exist.
+
+        Concrete subclasses implement the operation using whatever mechanism
+        necessary (ssh commands, REST HTTP requests, Django admin commands,
+        database queries, etc.).
+        """
+        pass
+
+
+class RemoteCommandFixture(WebAppFixture):
+    """
+    A fixture created by executing ssh commands on the remote host.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, hostname, ssh_user=None, ssh_keyfile=None):
+        """
+        Configure the fixture to execute on `hostname`.
+
+        `ssh_user` is the account to log in with via ssh
+        `ssh_keyfile` is the full path to the private ssh key
+        """
+        self.hostname = hostname
+        self.ssh_user = ssh_user
+        self.ssh_keyfile = ssh_keyfile
+
+    def install(self):
+        """
+        Execute ssh commands on the remote host.
+        """
+        try:
+            env.key_filename = self.ssh_keyfile
+
+            if self.ssh_user is not None:
+                host = "{0}@{1}".format(self.ssh_user, self.hostname)
+            else:
+                host = self.hostname
+
+            execute(self.execute, hosts=[host])
+
+        finally:
+            disconnect_all()
+
+    @abstractmethod
+    def execute(self):
+        """
+        Execute commands on the remote host using Fabric.
+        """
+        pass
+
+    def cmd(self, *args):
+        """
+        Helper method to construct a command string from component args.
+        """
+        return u" ".join([u"{0}".format(val) for val in args])

--- a/e2e_framework/web_app_test.py
+++ b/e2e_framework/web_app_test.py
@@ -3,6 +3,7 @@ Base class for testing a web application.
 """
 from unittest import TestCase
 from abc import ABCMeta, abstractproperty
+from uuid import uuid4
 from e2e_framework.web_app_ui import WebAppUI
 
 
@@ -21,6 +22,13 @@ class WebAppTest(TestCase):
     ui = None
 
     def setUp(self):
+
+        # Install fixtures provided by the concrete subclasses
+        # By the time this loop exits, all the test pre-conditions
+        # should be satisfied.
+        for fix in self.fixtures:
+            fix.install()
+
         # If using SauceLabs, tag the job with test info
         tags = [self.id()]
 
@@ -37,3 +45,20 @@ class WebAppTest(TestCase):
         during the test.
         """
         return []
+
+    @property
+    def fixtures(self):
+        """
+        Return a list of `WebAppFixture` subclasses
+        defining the pre-conditions for running the test.
+
+        Fixtures will be installed in the order provided.
+        """
+        return []
+
+    @property
+    def unique_id(self):
+        """
+        Helper method to return a uuid.
+        """
+        return str(uuid4().int)

--- a/fabfile.py
+++ b/fabfile.py
@@ -3,6 +3,7 @@ Commands for setting up test environments and running tests.
 """
 
 import os
+from ConfigParser import SafeConfigParser
 from fabric.api import *
 from fabric.contrib import files
 from textwrap import dedent
@@ -10,16 +11,10 @@ from path import path
 import requests
 
 
-# Use SSH config to authenticate with the integration server
-# Use ~/.ssh/config to define hosts and login information
-env.use_ssh_config = True
-
-
 REPO_ROOT = path(__file__).dirname()
 
-# Courses that will be imported before running the tests
-# These should be .tar.gz archives exported from Studio
-COURSE_FIXTURES = []
+# Path to the config file (defaults to config.ini, but can be overridden by the environment)
+CONFIG_PATH = os.environ.get("CONFIG_PATH", REPO_ROOT / "config.ini")
 
 # Number of tests to run in parallel, set by environment
 NUM_PARALLEL = os.environ.get('NUM_PARALLEL_TESTS', 1)
@@ -40,15 +35,9 @@ def test_edxapp(test_spec=None):
 
     to run only those tests.  If ommitted, run all the tests.
     """
-    _verify_host_configured()
-
-    # Ensure that the service is available before running the test suite
-    if not _available(env.host):
-        _abort("Could not contact '{0}'".format(env.host))
-
-    # Run the tests
+    config = _read_config('edxapp')
     test_path = str(REPO_ROOT / "test_edxapp")
-    _run_tests(test_path, test_spec, host_env_var='EDXAPP_HOST')
+    _run_tests(test_path, test_spec, config)
 
 
 def test_mktg(test_spec=None):
@@ -56,83 +45,100 @@ def test_mktg(test_spec=None):
     Execute the E2E test suite on an instance of the website administered by marketing.
     See test_edxapp docstring for 'test_spec' explanation and examples.
     """
-    _verify_host_configured()
-
+    config = _read_config('mktg')
     test_path = str(REPO_ROOT / "test_mktg")
-
-    _run_tests(test_path, test_spec)
-
-
-def install_courses(force=False):
-    """
-    Install course fixtures that the test suite depends on.
-
-    If `force` is True, upload the course even if it already exists.
-    """
-    _verify_host_configured()
-
-    confirm = prompt(
-        "Install fixture courses on {0}?".format(env.host),
-        default='y',
-        validate=lambda x: x.lower() == 'y'
-    )
-
-    if not confirm:
-        _abort("Cancelled")
-
-    for course_name, course_archive in COURSE_FIXTURES:
-
-        # Upload the course archive if we haven't already
-        remote_archive = path('/tmp') / course_archive
-        if not files.exists(remote_archive) or force:
-            print "Uploading {0}".format(remote_archive)
-            local_path = REPO_ROOT / "fixtures" / course_archive
-            result = put(str(local_path), str(remote_archive), use_sudo=True)
-
-            if not result.succeeded:
-                _abort("Upload failed: {0}".format(result))
-
-        else:
-            print "{0} already exists, skipping.".format(remote_archive)
-
-        # Unarchive the course if we haven't already
-        remote_data = path('/opt/wwc/data')
-        if not files.exists(remote_data / course_name) or force:
-
-            print "Unarchiving {0} to {1}".format(remote_archive, remote_data / course_name)
-
-            # Ensure that the archive has the right owner
-            sudo('chown www-data:www-data {0}'.format(remote_archive))
-
-            with settings(sudo_user="www-data"):
-                sudo('tar -zxvf {0} -C {1}'.format(remote_archive, remote_data))
-
-        else:
-            print "{0} already exists, skipping.".format(remote_data / course_name)
-
-        # Import the course
-        # Even if it already exists, this should override
-        # any changes that might have been made
-        # (We need to cd to the directory because the settings
-        # use the git SHA to version assets and will fail to load
-        # if we're not in a git repo.)
-        with cd('/opt/wwc/edx-platform'):
-            sudo(_manage_cmd('cms', 'xlint ../data {0}'.format(course_name)))
-            sudo(_manage_cmd('cms', 'import ../data {0}'.format(course_name)))
+    _run_tests(test_path, test_spec, config)
 
 
-def _available(hostname):
+def _available(protocol, hostname):
     """
     Return a boolean indicating whether the host
     at `hostname` is available (success HTTP response)
     """
 
     try:
-        resp = requests.get('http://' + hostname)
+        url = "{0}://{1}".format(protocol, hostname)
+        resp = requests.get(url)
     except requests.exceptions.ConnectionError:
         return False
 
     return resp.status_code == 200
+
+
+def _read_config(suite):
+    """
+    Read the config ini file for the test suite `suite`
+    (identified as a group in the config)
+
+    Returns a dictionary of configuration values that will
+    be passed as environment variables to the test suite.
+
+    Only `protocol` and `host` keys are required.
+    """
+    if not os.path.isfile(CONFIG_PATH):
+        msg = """
+            Could not find config file at '{0}'.
+            Please set the CONFIG_PATH environment variable
+        """.format(CONFIG_PATH)
+        _abort(msg)
+
+    config = SafeConfigParser()
+    config.read(CONFIG_PATH)
+
+    result = {
+        key: config.get(suite, key) for key in config.options(suite)
+    }
+
+    # Check that the required keys are defined
+    missing = []
+    for key in ['protocol', 'host']:
+        if key not in result:
+            missing.append(key)
+
+    if len(missing) > 0:
+        msg = "Test suite {0} is missing configuration values: {1}".format(
+            suite, missing.join(",")
+        )
+        _abort(msg)
+
+    return result
+
+
+def _run_tests(test_path, test_spec, config):
+    """
+    Assemble the test runner command and execute it.
+
+    `test_path` is the path in which the tests are located
+        Use this to restrict execution to a particular set of tests (e.g. edxapp or mktg)
+
+    `test_spec` is a nose-style test identifier, used to run a subset of tests.
+
+    `config` is a dict of configuration values (see `_read_config()` for details)
+    """
+
+    # Ensure that the service is available before running the test suite
+    if not _available(config['protocol'], config['host']):
+        _abort("Could not contact '{0}'".format(config['host']))
+
+    # Restrict to a subset of tests based on command-line arguments
+    if test_spec is not None:
+        test_path += "/" + test_spec
+
+    cmd_to_execute = _cmd('nosetests', test_path)
+
+    # Expose configuration options as environment variables
+    for key, val in config.iteritems():
+        cmd_to_execute = _cmd("{0}={1}".format(key, val), cmd_to_execute)
+
+    # Configure the tests to run in parallel
+    if NUM_PARALLEL > 1:
+        cmd_to_execute = _cmd(
+            cmd_to_execute,
+            '--processes={0}'.format(NUM_PARALLEL),
+            '--process-timeout={0}'.format(PROCESS_TIMEOUT)
+        )
+
+    local(cmd_to_execute)
 
 
 def _cmd(*args):
@@ -149,53 +155,3 @@ def _abort(msg):
     """
     print "ABORT: " + dedent(msg).strip()
     exit(0)
-
-
-def _manage_cmd(env, cmd):
-    return _cmd(
-        'SERVICE_VARIANT={0}'.format(env),
-        '/opt/edx/bin/django-admin.py', cmd,
-        '--settings={0}.envs.aws'.format(env),
-        '--pythonpath=/opt/wwc/edx-platform'
-    )
-
-
-def _verify_host_configured():
-    """
-    Verify that a host was defined.
-    """
-    if env.host is None:
-        _abort("""
-            Must specify at least one host.
-            See http://docs.fabfile.org/en/1.8/usage/execution.html#defining-host-lists
-        """)
-
-
-def _run_tests(test_path, test_spec, host_env_var=None):
-    """
-    Assemble the test runner command and execute it.
-
-    If you want to set up an environment variable e.g. for
-    using the hostname for the base url of the website under test,
-    pass it in so that it will be set as Fabric iterates through
-    each host in the host list.
-    """
-    if test_spec is not None:
-        test_path += "/" + test_spec
-
-    cmd_to_execute = _cmd('nosetests', test_path)
-
-    if host_env_var is not None:
-        cmd_to_execute = _cmd(
-            '{0}={1}'.format(host_env_var, env.host),
-            cmd_to_execute
-        )
-
-    if NUM_PARALLEL > 1:
-        cmd_to_execute = _cmd(
-            cmd_to_execute,
-            '--processes={0}'.format(NUM_PARALLEL),
-            '--process-timeout={0}'.format(PROCESS_TIMEOUT)
-        )
-
-    local(cmd_to_execute)

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+# Get the hostname of the instance from the environment
+# These are guaranteed to be defined by the fabric commands
+BASE_URL = "{0}://{1}".format(os.environ['protocol'], os.environ['host'])

--- a/pages/lms/__init__.py
+++ b/pages/lms/__init__.py
@@ -1,5 +1,0 @@
-import os
-
-# Get the hostname of the edxapp instance from the environment 
-EDXAPP_HOST = os.environ.get('EDXAPP_HOST')
-BASE_URL = "http://" + EDXAPP_HOST

--- a/pages/lms/course_about.py
+++ b/pages/lms/course_about.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class CourseAboutPage(PageObject):

--- a/pages/lms/dashboard.py
+++ b/pages/lms/dashboard.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class DashboardPage(PageObject):

--- a/pages/lms/find_courses.py
+++ b/pages/lms/find_courses.py
@@ -1,6 +1,6 @@
 from e2e_framework.page_object import PageObject
 from selenium.common.exceptions import WebDriverException
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class FindCoursesPage(PageObject):

--- a/pages/lms/info.py
+++ b/pages/lms/info.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class InfoPage(PageObject):

--- a/pages/lms/login.py
+++ b/pages/lms/login.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class LoginPage(PageObject):
@@ -25,3 +25,11 @@ class LoginPage(PageObject):
     def is_browser_on_page(self):
         page_title = self.css_text('span.title-super').lower()
         return 'log in' in page_title
+
+    def login(self, email, password):
+        """
+        Attempt to log in using `email` and `password`.
+        """
+        self.css_fill('input#email', email)
+        self.css_fill('input#password', password)
+        self.css_click('button#submit')

--- a/pages/lms/register.py
+++ b/pages/lms/register.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class RegisterPage(PageObject):

--- a/pages/mktg/__init__.py
+++ b/pages/mktg/__init__.py
@@ -1,5 +1,0 @@
-import os
-
-# Get the hostname of the edxapp instance from the environment
-MKTG_HOST = os.environ.get('MKTG_HOST')
-BASE_URL = "https://" + MKTG_HOST

--- a/pages/mktg/about_us.py
+++ b/pages/mktg/about_us.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class AboutUsPage(PageObject):

--- a/pages/mktg/bios.py
+++ b/pages/mktg/bios.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class BiosPage(PageObject):

--- a/pages/mktg/contact.py
+++ b/pages/mktg/contact.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class ContactPage(PageObject):

--- a/pages/mktg/course_list.py
+++ b/pages/mktg/course_list.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class CourseListPage(PageObject):

--- a/pages/mktg/edx_blog.py
+++ b/pages/mktg/edx_blog.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class EdxBlogPage(PageObject):

--- a/pages/mktg/edx_privacy_policy.py
+++ b/pages/mktg/edx_privacy_policy.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class PrivacyPolicyPage(PageObject):

--- a/pages/mktg/edx_terms_service.py
+++ b/pages/mktg/edx_terms_service.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class TermsOfServicePage(PageObject):

--- a/pages/mktg/home_page.py
+++ b/pages/mktg/home_page.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class HomePage(PageObject):

--- a/pages/mktg/how_it_works.py
+++ b/pages/mktg/how_it_works.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class HowItWorksPage(PageObject):

--- a/pages/mktg/jobs.py
+++ b/pages/mktg/jobs.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class JobsPage(PageObject):

--- a/pages/mktg/news.py
+++ b/pages/mktg/news.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class NewsPage(PageObject):

--- a/pages/mktg/org_faq.py
+++ b/pages/mktg/org_faq.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class OrgFaqPage(PageObject):

--- a/pages/mktg/research_pedagogy.py
+++ b/pages/mktg/research_pedagogy.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class ResearchPedagogyPage(PageObject):

--- a/pages/mktg/schools.py
+++ b/pages/mktg/schools.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class SchoolsPage(PageObject):

--- a/pages/mktg/student_faq.py
+++ b/pages/mktg/student_faq.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class StudentFaqPage(PageObject):

--- a/pages/mktg/verified_certificate.py
+++ b/pages/mktg/verified_certificate.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class VerifiedCertificatePage(PageObject):

--- a/pages/mktg/xseries.py
+++ b/pages/mktg/xseries.py
@@ -1,5 +1,5 @@
 from e2e_framework.page_object import PageObject
-from . import BASE_URL
+from pages import BASE_URL
 
 
 class XSeriesPage(PageObject):

--- a/test_edxapp/fixtures.py
+++ b/test_edxapp/fixtures.py
@@ -1,0 +1,62 @@
+"""
+Test fixtures for LMS and Studio.
+"""
+import os
+from fabric.api import sudo, settings
+from e2e_framework.web_app_fixture import RemoteCommandFixture, WebAppFixtureError
+
+
+class UserFixture(RemoteCommandFixture):
+    """
+    Ensure that a user exists.
+    """
+
+    def __init__(
+        self, username, email, password,
+        enrollment_mode="honor", course=None, is_staff=False):
+        """
+        Specify the required `username`, `password`, and `email` for
+        the new account.
+
+        `course` is the ID of the course to register the student in;
+        if omitted, do not enroll the student in any course.
+
+        `is_staff` is a boolean; if true, indicates that the user is a staff member.
+        (Note that this is different than being an instructor or course staff!)
+
+        `enrollment_mode` is either "honor", "verified", or "audit"
+        """
+        super(UserFixture, self).__init__(
+            os.environ['host'],
+            ssh_user=os.environ.get('ssh_user'),
+            ssh_keyfile=os.environ.get('ssh_keyfile')
+        )
+        self.username = username
+        self.password = password
+        self.email = email
+        self.enrollment_mode = enrollment_mode
+        self.course = course
+        self.is_staff = is_staff
+
+    def execute(self):
+        """
+        Use a Django management command to create a user.
+        This operation is idempotent.
+        """
+        command = self.cmd(
+            'SERVICE_VARIANT=lms', '/edx/app/edxapp/venvs/edxapp/bin/python',
+            '/edx/app/edxapp/edx-platform/manage.py', 'lms', '--settings=aws',
+            'create_user', '-u', self.username, '-e', self.email, '-p', self.password,
+            '-m', self.enrollment_mode
+        )
+
+        if self.is_staff:
+            command = self.cmd(command, '-s')
+
+        if self.course is not None:
+            command = self.cmd(command, "-c", self.course)
+
+        with settings(sudo_user='edxapp'):
+            result = sudo(command)
+            if result.failed:
+                raise WebAppFixtureError(result)

--- a/test_edxapp/test_lms.py
+++ b/test_edxapp/test_lms.py
@@ -5,6 +5,7 @@ E2E tests for the LMS.
 
 from e2e_framework.web_app_test import WebAppTest
 from credentials import TestCredentials
+from fixtures import UserFixture
 from pages.lms.login import LoginPage
 from pages.lms.find_courses import FindCoursesPage
 from pages.lms.info import InfoPage
@@ -13,14 +14,17 @@ from pages.lms.register import RegisterPage
 from pages.lms.dashboard import DashboardPage
 
 
+# The demo course is installed by default in the CI environment
+DEMO_COURSE_ID = 'edX/Open_DemoX/edx_demo_course'
+DEMO_COURSE_TITLE = 'Open_DemoX edX Demonstration Course'
+
+
 class LoggedOutTest(WebAppTest):
     """
     Smoke test for pages in the LMS
     that are visible when logged out.
     """
 
-    DEMO_COURSE_ID = 'edX/Open_DemoX/edx_demo_course'
-    DEMO_COURSE_TITLE = 'Open_DemoX edX Demonstration Course'
 
     @property
     def page_object_classes(self):
@@ -31,9 +35,6 @@ class LoggedOutTest(WebAppTest):
 
     def test_find_courses(self):
         self.ui.visit('lms.find_courses')
-
-    def test_login(self):
-        self.ui.visit("lms.login")
 
     def test_info(self):
 
@@ -47,10 +48,10 @@ class LoggedOutTest(WebAppTest):
 
         # Expect that the demo course exists
         course_ids = self.ui['lms.find_courses'].course_id_list()
-        self.assertIn(self.DEMO_COURSE_ID, course_ids)
+        self.assertIn(DEMO_COURSE_ID, course_ids)
 
         # Go to the course about page
-        self.ui['lms.find_courses'].go_to_course(self.DEMO_COURSE_ID)
+        self.ui['lms.find_courses'].go_to_course(DEMO_COURSE_ID)
 
         # Click the register button
         self.ui['lms.course_about'].register()
@@ -62,4 +63,31 @@ class LoggedOutTest(WebAppTest):
         # We should end up at the dashboard
         # Check that we're registered for the course
         course_names = self.ui['lms.dashboard'].available_courses()
-        self.assertIn(self.DEMO_COURSE_TITLE, course_names)
+        self.assertIn(DEMO_COURSE_TITLE, course_names)
+
+
+class LoggedInTest(WebAppTest):
+    """
+    Tests that log in as a user.
+    """
+
+    @property
+    def page_object_classes(self):
+        return [LoginPage, DashboardPage]
+
+    @property
+    def fixtures(self):
+        """
+        Create a user account so we can log in.
+        """
+        self.username = 'test_' + self.unique_id
+        self.email = '{0}@example.com'.format(self.username)
+        self.password = 'password'
+
+        return [UserFixture(self.username, self.email, self.password, course=DEMO_COURSE_ID)]
+
+    def test_login(self):
+        self.ui.visit('lms.login')
+        self.ui['lms.login'].login(self.email, self.password)
+        course_names = self.ui['lms.dashboard'].available_courses()
+        self.assertIn(DEMO_COURSE_TITLE, course_names)


### PR DESCRIPTION
Extended the framework to allow for "fixtures".  This is an abstraction that I think will be useful for doing test setup via Django management commands or REST APIs.

I also updated the fabric file to use configuration files instead of Fabric hosts.  This will require some updates to the Jenkins jobs to install and use the appropriate configuration file.

I've added a proof-of-concept test to demonstrate how to use fixtures to ensure a user account exists before logging in.
- Created WebAppFixture to encapsulate test setup
- Created UserFixture for LMS tests
- Use config file for test environment parameters
- Implemented login test to demonstrate UserFixture
- Remove install course script

@jzoldak What do you think?
