### PR TITLE
Disabled video test until BLD-563 is fixed

### DIFF
--- a/test_lms/test_lms.py
+++ b/test_lms/test_lms.py
@@ -2,6 +2,7 @@
 E2E tests for the LMS.
 """
 
+from unittest import skip
 from bok_choy.web_app_test import WebAppTest
 from bok_choy.promise import EmptyPromise, fulfill_before
 from credentials import TestCredentials
@@ -152,6 +153,7 @@ class HighLevelTabTest(LoggedInTest):
         for expected in EXPECTED_ITEMS:
             self.assertIn(expected, actual_items)
 
+    @skip("BLD-563: Video Player Stuck on Pause")
     def test_video_player(self):
         """
         Play a video in the courseware.


### PR DESCRIPTION
The E2E tests found a browser-specific bug in the video player.  The Blades team has put it in the backlog as a CAT-3; the test should be re-enabled when it gets fixed.

@jzoldak 
