### PR TITLE
Fix the vagrant-based development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ src
 
 # Screenshots on failure
 log/*.png
+
+# Local environment
+local_env.sh

--- a/README.rst
+++ b/README.rst
@@ -28,34 +28,53 @@ We recommend using the provided Vagrant environment to develop and run tests.
 
 3. This will create and provision a new Vagrant environment.
 
-You will also need an installation of the edX to run the tests on.
+4. Enter a terminal session in the virtual environment with:
+
+.. code:: bash
+
+    vagrant ssh
+
+
+You will also need a deployed installation of edX lms and studio to run the tests against.
 See `edx/configuration <http://github.com/edx/configuration>`_ for instructions on provisioning an edX instance.
 
 
 
 Configuration
 -------------
-Before running the commands change your working directory to `edx-e2e-tests`
 
-1. Install requirements:
+1. Before running the commands change your working directory to `edx-e2e-tests`. Note that
+   the 'e2e' python virtual environment will automatically be activated.
+
+.. code:: bash
+
+    cd edx-e2e-tests/
+
+2. Update the base python requirements in case they have changed
+   since you created the vagrant environment:
 
 .. code:: bash
 
     pip install -r requirements/base.txt
 
-2 - Install edx platform pages:
+3. OPTIONAL: Cloning the edx-platform repo into a mounted directory in a vagrant environment
+   can take a long time (several minutes). An alternative is to navigate to the lib directory
+   back on your host system and clone the edx-platform repo there before proceeding.
+
+4. Install the page objects for the application from the edx platform repo. This will
+   clone the entire repo into lib/edx-platform so that it can use the page objects and
+   helper methods from common/test/acceptance. We also install capa and xmodule into the
+   virtual environment from common/lib.
+
 
 .. code:: bash
 
     paver install_pages
 
 
-
 Running Tests Locally
 ---------------------
-
-Within the Vagrant environment, the tests are installed in /opt/dev/edx-e2e-tests,
-so before running the paver commands:
+Make sure you are in the correct folder.
 
 .. code:: bash
 
@@ -72,15 +91,11 @@ To run the tests locally, following environmental variables needs to be changed 
     ==> USER_LOGIN_PASSWORD
 
 
-
 To run all the tests:
 
 .. code:: bash
 
     paver e2e_test
-
-
-
 
 
 The commands also accept nose-style specifiers for test case or module:
@@ -89,19 +104,19 @@ To run all the tests in the file:
 
 .. code:: bash
 
-    paver e2e_test lms/test_dasboard.py
+    paver e2e_test lms/test_dashboard.py
 
 To run all the tests in a particular class:
 
 .. code:: bash
 
-    paver e2e_test lms/test_dasboard.py: DashboardTest
+    paver e2e_test lms/test_dashboard.py:DashboardTest
 
 To run a single test:
 
 .. code:: bash
 
-    paver e2e_test lms/test_dasboard.py: DashboardTest.test_resume_course
+    paver e2e_test lms/test_dashboard.py:DashboardTest.test_resume_course
 
 
 To update page objects installed from external repos:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,9 +9,9 @@ $script = <<SCRIPT
 
     # Install system requirements
     apt-get update -y
-    apt-get install -y git python2.7 python-pip python2.7-dev firefox dbus-x11 vim
-    apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev     libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
-    apt-get install -y libxslt1-dev libxml2-dev
+    apt-get install -y git python2.7 python-pip python2.7-dev firefox dbus-x11 vim libjpeg-dev libxml2-dev
+libxslt-dev
+    apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
     pip install virtualenv==1.10.1
     pip install virtualenvwrapper
 
@@ -23,9 +23,9 @@ source /usr/local/bin/virtualenvwrapper.sh
 source /home/vagrant/.virtualenvs/e2e/bin/activate
 INIT
 
-    # Install Python requirements and page objects
+    # Install Python requirements
     sudo -u vagrant virtualenv /home/vagrant/.virtualenvs/e2e
-    sudo -u vagrant PYTHONUNBUFFERED=1 sh -c ". /home/vagrant/.virtualenvs/e2e/bin/activate && pip install -r /home/vagrant/edx-e2e-tests/requirements/base.txt && cd /home/vagrant/edx-e2e-tests/; paver install_pages"
+    sudo -u vagrant PYTHONUNBUFFERED=1 sh -c ". /home/vagrant/.virtualenvs/e2e/bin/activate && STATIC_DEPS=true CFLAGS="-O0 -fPIC"  pip install "lxml==3.4.4" && pip install -r /home/vagrant/edx-e2e-tests/requirements/base.txt"
 
 SCRIPT
 
@@ -34,15 +34,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network :forwarded_port, guest: 80, host: 8080
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  config.vm.network :private_network, ip: "192.168.33.10"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,8 @@ $script = <<SCRIPT
     # Install system requirements
     apt-get update -y
     apt-get install -y git python2.7 python-pip python2.7-dev firefox dbus-x11 vim
+    apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev     libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
+    apt-get install -y libxslt1-dev libxml2-dev
     pip install virtualenv==1.10.1
     pip install virtualenvwrapper
 
@@ -23,7 +25,7 @@ INIT
 
     # Install Python requirements and page objects
     sudo -u vagrant virtualenv /home/vagrant/.virtualenvs/e2e
-    sudo -u vagrant PYTHONUNBUFFERED=1 sh -c ". /home/vagrant/.virtualenvs/e2e/bin/activate && pip install -r /home/vagrant/edx-e2e-tests/requirements/base.txt && fab -f /home/vagrant/edx-e2e-tests/fabfile.py install_pages"
+    sudo -u vagrant PYTHONUNBUFFERED=1 sh -c ". /home/vagrant/.virtualenvs/e2e/bin/activate && pip install -r /home/vagrant/edx-e2e-tests/requirements/base.txt && cd /home/vagrant/edx-e2e-tests/; paver install_pages"
 
 SCRIPT
 

--- a/local_env.sh.sample
+++ b/local_env.sh.sample
@@ -1,0 +1,13 @@
+# Local environment setup example
+# Copy to a new file (local_env.sh) and fill the blanks
+# Use the 'source local_env.sh' to setup your environment
+
+export BASIC_AUTH_USER=<FILLIN>
+export BASIC_AUTH_PASSWORD=<FILLIN>
+export USER_LOGIN_EMAIL=<FILLIN>
+export USER_LOGIN_PASSWORD=<FILLIN>
+export COURSE_ORG=<FILLIN>
+export COURSE_NUMBER=<FILLIN>
+export COURSE_RUN=<FILLIN>
+export COURSE_DISPLAY_NAME=<FILLIN>
+


### PR DESCRIPTION
* Update documentation
* Install additional required system dependencies
* Remove attempted usage of fabric, which was already removed
* Do not install the page objects when provisioning anyhow, as this clones the entire edx-platform repo and takes a very long time (especially on a synced folder)

Note that this still installs the apt-get version of firefox, which likely (and at the time of this writing -definitely) will not work with the version of selenium and drivers that are installed.

@edx/testeng 