### PR TITLE
Fix paver install_pages xslt library dependency

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,7 @@ $script = <<SCRIPT
 
     # Install system requirements
     apt-get update -y
-    apt-get install -y git python2.7 python-pip python2.7-dev firefox dbus-x11 vim libjpeg-dev libxml2-dev
-libxslt-dev
+    apt-get install -y git python2.7 python-pip python2.7-dev firefox dbus-x11 vim libjpeg-dev libxml2-dev libxslt1-dev
     apt-get install -y libtiff4-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
     pip install virtualenv==1.10.1
     pip install virtualenvwrapper


### PR DESCRIPTION
Background: The vagrant script installs dependencies that will then be used in the subsequent setup commands. Seems that one dependency (libxslt1-dev) was missing and one was not necessary (libxslt-dev)

Testing: Run vagrant up or vagrant provision and then paver install_pages once logged into the VM