### PR TITLE
Do not fail tests if the saving notification is missed.

### DIFF
--- a/regression/pages/studio/pages_page_studio.py
+++ b/regression/pages/studio/pages_page_studio.py
@@ -2,13 +2,13 @@
 Extended Pages page for a course.
 """
 from selenium.webdriver import ActionChains
-from edxapp_acceptance.pages.common.utils import (
-    wait_for_notification,
-    click_css
-)
+from edxapp_acceptance.pages.common.utils import click_css
 from edxapp_acceptance.pages.studio.utils import drag
 
-from regression.pages.studio.utils import click_css_with_animation_enabled
+from regression.pages.studio.utils import (
+    click_css_with_animation_enabled,
+    sync_on_notification
+)
 from regression.pages.studio.course_page_studio import CoursePageExtended
 
 
@@ -56,7 +56,7 @@ class PagesPageExtended(CoursePageExtended):
             'document.querySelectorAll(".button.action-primary'
             '.action-save")[0].click();'
         )
-        wait_for_notification(self)
+        sync_on_notification(self)
 
     def delete_page(self, index=0):
         """
@@ -72,7 +72,7 @@ class PagesPageExtended(CoursePageExtended):
             require_notification=False
         )
         self.q(css='.prompt.warning button.action-primary ').first.click()
-        wait_for_notification(self)
+        sync_on_notification(self)
 
     def delete_all_pages(self):
         """
@@ -153,7 +153,7 @@ class PagesPageExtended(CoursePageExtended):
         ActionChains(self.browser).move_to_element(
             toggle_checkbox
         ).click().perform()
-        wait_for_notification(self)
+        sync_on_notification(self)
         # Complicated query, so executing using jQuery.
         return self.browser.execute_script(
             "return $('{}:eq({})').parents().eq(3).find("

--- a/regression/pages/studio/utils.py
+++ b/regression/pages/studio/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for studio page objects.
 """
+from bok_choy.promise import BrokenPromise
 from opaque_keys.edx.locator import CourseLocator
 from edxapp_acceptance.pages.common.utils import wait_for_notification
 from edxapp_acceptance.pages.studio.utils import press_the_notification_button
@@ -154,3 +155,21 @@ def get_text(page, css, index=0):
         index (int): index position of element.
     """
     return page.q(css=css).text[index]
+
+
+def sync_on_notification(page):
+    """
+    Wait for the saving notification to appear then disappear.
+
+    A BrokenPromise probably means that we missed it.
+    We should just swallow this error and not raise it for
+    reasons including:
+    * We are not specifically testing this functionality
+    * This functionality is covered by unit tests
+    * This verification method is prone to flakiness
+      and browser version dependencies
+    """
+    try:
+        wait_for_notification(page)
+    except BrokenPromise as _err:
+        pass


### PR DESCRIPTION
This should solve the current flakiness for TE-1944. I'd like to get this in now. 

Out of scope for this PR but opportunities for later improvement/refactoring:
* Find the other usages in this repo and use it there too
* Submit as a new method upstream to the bok-choy repo. For this I would suggest keeping the wait_for_notification method name, and adding to it a keyword argument that will retain the default behavior and allow overriding to catch/swallow the exceptions.
* I'm not sure we even ever need to wait for the notification as a synchronization point anyhow. For this new logic, the worst case will be that we waste an extra 60 seconds (the default value in the bok-choy code) waiting for a promise that is broken. That seems however to be much less than the time we will spend troubleshooting future possible flakiness if we don't wait and the change is not yet saved.

FWIW I was able to run these changes locally, with it happening to both traverse through the new logic (it didn't see the popup) as well as the original (the notification was seen) logic.