### PR TITLE
Improve page object for test_html_component test

### DIFF
--- a/regression/pages/lms/lms_courseware.py
+++ b/regression/pages/lms/lms_courseware.py
@@ -22,4 +22,8 @@ class CoursewarePageExtended(CoursewarePage):
         """
         Clicks on the 'View unit in Studio' button
         """
+        self.wait_for_element_visibility(
+            '.instructor-info-action',
+            'View unit in Studio link is visible'
+        )
         self.q(css='.instructor-info-action').click()


### PR DESCRIPTION
@raeeschachar @Muddasser @estute 

I'm pretty sure that this makes a flaky condition more apparent - the link is not always there. Actually it seems as tho other staff-only UI, like "Staff Debug Info" and "Submission History" are missing too.

@nasthagiri was concerned that this may be uncovering a real issue. It needs investigation, so I'm leaving this here as a reminder. If any of you guys wants to pick it up go for it. Feel free to take over this branch or cherry-pick the commit, or whatever is easiest.