### PR TITLE
separate user test data based on ci tests

### DIFF
--- a/regression/pages/ecommerce/coupon_const.py
+++ b/regression/pages/ecommerce/coupon_const.py
@@ -2,6 +2,7 @@
 """
 Constant used in coupon tests
 """
+import os
 from datetime import datetime, timedelta
 
 from regression.pages.whitelabel.const import ORG

--- a/regression/pages/ecommerce/coupon_const.py
+++ b/regression/pages/ecommerce/coupon_const.py
@@ -84,21 +84,50 @@ STOCK_RECORD_ID = STOCK_RECORD_IDS[ORG]
 
 # Coupon users
 
-COUPON_USERS = {
-    'coupon_user_01': 'wl_coupon_user01@example.com',
-    'coupon_user_02': 'wl_coupon_user02@example.com',
-    'coupon_user_03': 'wl_coupon_user03@example.com'
+# In order to avoid collisions between various CI jobs, separate some of
+# the user account data
+USER_DATA_SET = os.getenv('USER_DATA_SET', 'pipeline')
+
+COUPON_USER_SETS = {
+    'pipeline': {
+        'coupon_user_01': 'wl_coupon_user01@example.com',
+        'coupon_user_02': 'wl_coupon_user02@example.com',
+        'coupon_user_03': 'wl_coupon_user03@example.com'
+    },
+    'pr': {
+        'coupon_user_01': 'ms_coupon_user01@example.com',
+        'coupon_user_02': 'ms_coupon_user02@example.com',
+        'coupon_user_03': 'ms_coupon_user03@example.com'
+    }
 }
 
-VALID_DOMAIN_USERS = {
-    'coupon_user_04': 'wl_coupon_user04@emaildomainfour.com',
-    'coupon_user_05': 'wl_coupon_user05@emaildomainfive.com'
+VALID_DOMAIN_SETS = {
+    'pipeline': {
+        'coupon_user_04': 'wl_coupon_user04@emaildomainfour.com',
+        'coupon_user_05': 'wl_coupon_user05@emaildomainfive.com'
+    },
+    'pr': {
+        'coupon_user_04': 'ms_coupon_user04@emaildomainfour.com',
+        'coupon_user_05': 'ms_coupon_user05@emaildomainfive.com'
+    }
 }
 
-INVALID_DOMAIN_USERS = {
-    'coupon_user_06': 'wl_coupon_user06@emaildomainsix.com',
-    'coupon_user_07': 'wl_coupon_user07@emaildomainseven.com'
+INVALID_DOMAIN_SETS = {
+    'pipeline': {
+        'coupon_user_06': 'wl_coupon_user06@emaildomainsix.com',
+        'coupon_user_07': 'wl_coupon_user07@emaildomainseven.com'
+    },
+    'pr': {
+        'coupon_user_06': 'ms_coupon_user06@emaildomainsix.com',
+        'coupon_user_07': 'ms_coupon_user07@emaildomainseven.com'
+    }
 }
+
+COUPON_USERS = COUPON_USER_SETS[USER_DATA_SET]
+
+VALID_DOMAIN_USERS = VALID_DOMAIN_SETS[USER_DATA_SET]
+
+INVALID_DOMAIN_USERS = INVALID_DOMAIN_SETS[USER_DATA_SET]
 
 # Email domains
 

--- a/regression/pages/whitelabel/const.py
+++ b/regression/pages/whitelabel/const.py
@@ -145,14 +145,28 @@ BILLING_INFO = {
     'expiry_year': '2018'
 }
 
+# In order to avoid collisions between various CI jobs, separate some of
+# the user account data
+USER_DATA_SET = os.getenv('USER_DATA_SET', 'pipeline')
+
 # Existing user email
-EXISTING_USER_EMAIL = 'wl_smoke_user01@example.com'
+EXISTING_USER_EMAILS = {
+        'pipeline': 'wl_smoke_user01@example.com',
+        'pr': 'ms_smoke_user01@example.com'
+}
+
+EXISTING_USER_EMAIL = EXISTING_USER_EMAILS[USER_DATA_SET]
+
+# Student user email
+VISUAL_USER_EMAILS = {
+    'pipeline': 'wl_visual_test01@example.com',
+    'pr': 'ms_visual_test01@example.com'
+}
+
+VISUAL_USER_EMAIL = VISUAL_USER_EMAILS[USER_DATA_SET]
 
 # Staff user email
 STAFF_EMAIL = os.environ['STAFF_USER_EMAIL']
-
-# Student user email
-VISUAL_USER_EMAIL = 'wl_visual_test01@example.com'
 
 # Default Threshold for visual difference
 DIFF_THRESHOLD = 5000


### PR DESCRIPTION
@jzoldak  In order to run both the white-label job on pipeline deployments and pull requests (possibly concurrently), we needed to create some additional user account data to avoid conflicts with user state (thank you @kashifch). 