### PR TITLE
Fix flakiness in creating new sections and subsections

### DIFF
--- a/regression/pages/studio/course_outline_page.py
+++ b/regression/pages/studio/course_outline_page.py
@@ -36,7 +36,7 @@ class CourseOutlinePageExtended(CourseOutlinePage):
             css=section_css
         ).results[0].send_keys(text)
 
-        self.q(css='.content').first.click()
+        self.q(css='.section-status').first.click()
         # Click initiates an ajax call
         self.wait_for_ajax()
 
@@ -63,7 +63,7 @@ class CourseOutlinePageExtended(CourseOutlinePage):
             css=subsection_css
         ).results[-1].send_keys(text)
 
-        self.q(css='.content').first.click()
+        self.q(css='.subsection-status').first.click()
         # Click initiates an ajax call
         self.wait_for_ajax()
 


### PR DESCRIPTION
Click on the status row instead of the overall content area to finish editing a section or sub-section name; the old behavior sometimes inadvertently resulted in a click on the new unit button within that area.  This has caused several random test failures recently.