### PR TITLE
PLAT-1590 Remove stray semicolon in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - pep8 regression/
   - pylint regression/
 after_success:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then;
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     docker --version;
     sudo apt-get -y update;
     sudo apt-get -y install -o Dpkg::Options::="--force-confnew" docker-ce;


### PR DESCRIPTION
The Travis job for master passed, but failed to build and upload the Docker image due to a stray semicolon.  Removing that and trying again.