### PR TITLE
Set correct session cookie domain for staging environment TE-2207

### DIFF
--- a/regression/pages/lms/lms_textbook.py
+++ b/regression/pages/lms/lms_textbook.py
@@ -1,8 +1,7 @@
 """
 Textbook page LMS
 """
-from bok_choy.page_object import PageObject, unguarded
-from regression.pages.lms.utils import workaround_login_redirect
+from bok_choy.page_object import PageObject
 
 
 class TextbookPage(PageObject):
@@ -13,8 +12,3 @@ class TextbookPage(PageObject):
 
     def is_browser_on_page(self):
         return self.q(css='.chapter').visible
-
-    @unguarded
-    def visit(self):
-        workaround_login_redirect(self)
-        super(TextbookPage, self).visit()

--- a/regression/pages/lms/utils.py
+++ b/regression/pages/lms/utils.py
@@ -1,9 +1,7 @@
 """
 Utility functions for lms page objects.
 """
-import os
 from opaque_keys.edx.locator import CourseLocator
-from regression.pages.lms.login_lms import LmsLogin
 
 
 def get_course_key(course_info, module_store='split'):
@@ -19,17 +17,3 @@ def get_course_key(course_info, module_store='split'):
         deprecated=(module_store == 'draft')
     )
     return unicode(course_key)
-
-
-def workaround_login_redirect(page):
-    """
-    Temporary workaround while we investigate the root cause
-    of the user being redirected to the login page. TE-2207
-    """
-    page.browser.get(page.url)
-    if page.browser.current_url.find('/signin?next=') > 0:
-        user = os.environ.get('USER_LOGIN_EMAIL')
-        password = os.environ.get('USER_LOGIN_PASSWORD')
-        login_page = LmsLogin(page.browser)
-        login_page.provide_info(user, password)
-        login_page.submit()

--- a/regression/pages/studio/course_outline_page.py
+++ b/regression/pages/studio/course_outline_page.py
@@ -1,12 +1,10 @@
 """
 Course Outline Page for Studio
 """
-from bok_choy.page_object import unguarded
 from edxapp_acceptance.pages.studio.overview import CourseOutlinePage
 from selenium.webdriver.common.action_chains import ActionChains
 from regression.pages.studio.utils import (
-    click_confirmation_prompt_primary_button,
-    workaround_login_redirect
+    click_confirmation_prompt_primary_button
 )
 
 from regression.tests.helpers.utils import get_url
@@ -22,11 +20,6 @@ class CourseOutlinePageExtended(CourseOutlinePage):
         Construct a URL to the page within the course.
         """
         return get_url(self.url_path, self.course_info)
-
-    @unguarded
-    def visit(self):
-        workaround_login_redirect(self)
-        super(CourseOutlinePageExtended, self).visit()
 
     def add_section_with_name(self, text):
         """

--- a/regression/pages/studio/studio_home.py
+++ b/regression/pages/studio/studio_home.py
@@ -3,15 +3,11 @@ Dashboard page for Studio
 """
 from edxapp_acceptance.pages.studio.index import DashboardPage
 from edxapp_acceptance.tests.helpers import disable_animations
-from bok_choy.page_object import unguarded
 from bok_choy.promise import BrokenPromise
 
 from regression.pages.studio import LOGIN_BASE_URL
 from regression.pages.lms import LMS_REDIRECT_URL
-from regression.pages.studio.utils import (
-    get_course_key,
-    workaround_login_redirect
-)
+from regression.pages.studio.utils import get_course_key
 from regression.tests.helpers.utils import get_course_info
 
 
@@ -28,11 +24,6 @@ class DashboardPageExtended(DashboardPage):
         Verifies if the browser is on the correct page
         """
         return self.q(css='.courses.courses-tab.active').visible
-
-    @unguarded
-    def visit(self):
-        workaround_login_redirect(self)
-        super(DashboardPageExtended, self).visit()
 
     def select_course(self, course_title):
         """

--- a/regression/pages/studio/studio_textbooks.py
+++ b/regression/pages/studio/studio_textbooks.py
@@ -1,13 +1,11 @@
 """
 Extended Textbooks page
 """
-from bok_choy.page_object import unguarded
 from edxapp_acceptance.pages.studio.textbook_upload import TextbookUploadPage
 
 from selenium.webdriver.common.action_chains import ActionChains
 from regression.pages import UPLOAD_FILE_DIR
 from regression.tests.helpers.utils import get_url
-from regression.pages.studio.utils import workaround_login_redirect
 
 
 class TextbookPageExtended(TextbookUploadPage):
@@ -20,11 +18,6 @@ class TextbookPageExtended(TextbookUploadPage):
         Construct a URL to the page within the course.
         """
         return get_url(self.url_path, self.course_info)
-
-    @unguarded
-    def visit(self):
-        workaround_login_redirect(self)
-        super(TextbookPageExtended, self).visit()
 
     def upload_textbook(self, file_name):
         """

--- a/regression/pages/studio/utils.py
+++ b/regression/pages/studio/utils.py
@@ -1,12 +1,10 @@
 """
 Utility functions for studio page objects.
 """
-import os
 from opaque_keys.edx.locator import CourseLocator
 from edxapp_acceptance.pages.common.utils import click_css
 from edxapp_acceptance.tests.helpers import disable_animations
 from regression.pages import UPLOAD_FILE_DIR
-from regression.pages.studio.login_studio import StudioLogin
 
 
 def get_course_key(course_info, module_store='split'):
@@ -74,16 +72,3 @@ def get_text(page, css, index=0):
         index (int): index position of element.
     """
     return page.q(css=css).text[index]
-
-
-def workaround_login_redirect(page):
-    """
-    Temporary workaround while we investigate the root cause
-    of the user being redirected to the login page. TE-2207
-    """
-    page.browser.get(page.url)
-    if page.browser.current_url.find('/signin?next=') > 0:
-        user = os.environ.get('USER_LOGIN_EMAIL')
-        password = os.environ.get('USER_LOGIN_PASSWORD')
-        studio_login_page = StudioLogin(page.browser)
-        studio_login_page.login(user, password)

--- a/regression/tests/helpers/api_clients.py
+++ b/regression/tests/helpers/api_clients.py
@@ -125,14 +125,19 @@ class LoginApiBaseClass(object):
         # effective, we don't need to login.
         browser.get(self.browser_get_url)
         for cookie in self.session.cookies:
-            browser.add_cookie(
-                {
-                    'name': cookie.name,
-                    'value': cookie.value,
-                    'path': cookie.path,
-                    'expiry': cookie.expires
-                }
-            )
+            cookie_dict = {
+                'name': cookie.name,
+                'value': cookie.value,
+                'path': cookie.path,
+                'expiry': cookie.expires
+            }
+            # The domain for the sessionid cookie needs to be
+            # '.stage.edx.org'. The browser was setting it correctly
+            # when logging into lms, but was setting it to
+            # 'studio.stage.edx.org' when logging into studio.
+            if cookie.name == 'stage-edx-sessionid':
+                cookie_dict['domain'] = '.stage.edx.org'
+            browser.add_cookie(cookie_dict)
         browser.get(self.browser_get_url)
 
 


### PR DESCRIPTION
@estute @feanil I am unsure why this stopped working. Could there have been a change to the configuration of the staging environment? I can't find any trail of changes to the tests or their requirements (requests library and selenium are pinned, browser version has not been changed/updated, etc.)
At any rate, this fixes the issue and explains why we were unable to reproduce it manually through just the browser.