### PR TITLE
Fix target css for TOS page

### DIFF
--- a/regression/pages/studio/terms_of_service.py
+++ b/regression/pages/studio/terms_of_service.py
@@ -13,5 +13,5 @@ class TermsOfService(PageObject):
 
     def is_browser_on_page(self):
         return "Please read these Terms of Service" in self.q(
-            css='.field-page-body'
+            css='.content-section'
         ).text[0]


### PR DESCRIPTION
@estute @michaelyoungstrom 

The e2e tests in the CD pipeline are failing due to this css change.
I looked quickly to relate it back to a commit that changed the css class, but it wasn't immediately apparent so I am fixing and tagging you guys for a thumbs up. This should get us back to green.