### PR TITLE
update lxml to 4.0.0

### DIFF
--- a/jenkins/end_to_end_tests.sh
+++ b/jenkins/end_to_end_tests.sh
@@ -22,7 +22,7 @@ pip install -r requirements/base.txt > log/pip_install_base.log
 # Install the page objects from the edx-platform repo.
 # Before doing so, we don't need optimizations for lxml,
 # so install it this way which doesn't bother compiling them.
-STATIC_DEPS=true CFLAGS="-O0"  pip install "lxml==3.4.4" > log/pip_lxml_install.log
+STATIC_DEPS=true CFLAGS="-O0"  pip install "lxml==4.0.0" > log/pip_lxml_install.log
 paver install_pages > log/paver_install_pages.log
 
 # Set the display to the virtual frame buffer (Xvfb)

--- a/jenkins/enterprise.sh
+++ b/jenkins/enterprise.sh
@@ -22,7 +22,7 @@ pip install -r requirements/base.txt > log/pip_install_base.log
 # Install the page objects from the edx-platform repo.
 # Before doing so, we don't need optimizations for lxml,
 # so install it this way which doesn't bother compiling them.
-STATIC_DEPS=true CFLAGS="-O0"  pip install "lxml==3.4.4" > log/pip_lxml_install.log
+STATIC_DEPS=true CFLAGS="-O0"  pip install "lxml==4.0.0" > log/pip_lxml_install.log
 paver install_pages > log/paver_install_pages.log
 
 # Set the display to the virtual frame buffer (Xvfb)

--- a/jenkins/white_label.sh
+++ b/jenkins/white_label.sh
@@ -22,7 +22,7 @@ pip install -r requirements/base.txt
 # Install the page objects from the edx-platform repo.
 # Before doing so, we don't need optimizations for lxml,
 # so install it this way which doesn't bother compiling them.
-STATIC_DEPS=true CFLAGS="-O0"  pip install "lxml==3.4.4" > log/pip_lxml_install.log
+STATIC_DEPS=true CFLAGS="-O0"  pip install "lxml==4.0.0" > log/pip_lxml_install.log
 paver install_pages > log/paver_install_pages.log
 
 


### PR DESCRIPTION
e2e tests were failing due to a dependency of the version of lxml we are pinning in the jenkins scripts. This version will successfully install, but going over the changelog for lxml just to be sure.