### PR TITLE
WL-1435 Page wait experiment to fix page load failures

### DIFF
--- a/regression/pages/whitelabel/activate_account.py
+++ b/regression/pages/whitelabel/activate_account.py
@@ -1,10 +1,10 @@
 """
 Page for account activation
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 
-class ActivateAccount(PageObject):
+class ActivateAccount(NewPageObject):
     """
     Account activation page.
     """

--- a/regression/pages/whitelabel/basket_page.py
+++ b/regression/pages/whitelabel/basket_page.py
@@ -1,7 +1,7 @@
 """
 Pages for single course and multi course purchase baskets
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.whitelabel.const import ECOMMERCE_URL_WITH_AUTH
 
@@ -12,7 +12,7 @@ from regression.pages.common.utils import (
 )
 
 
-class BasketPage(PageObject):
+class BasketPage(NewPageObject):
     """
     Generic class for E-Commerce basket pages
     """

--- a/regression/pages/whitelabel/course_about_page.py
+++ b/regression/pages/whitelabel/course_about_page.py
@@ -1,12 +1,12 @@
 """
 Course About page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.whitelabel.const import URL_WITH_AUTH
 
 
-class CourseAboutPage(PageObject):
+class CourseAboutPage(NewPageObject):
     """
     Course About page class
     """

--- a/regression/pages/whitelabel/courses_page.py
+++ b/regression/pages/whitelabel/courses_page.py
@@ -1,12 +1,12 @@
 """
 Courses page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.whitelabel.const import URL_WITH_AUTH
 
 
-class CoursesPage(PageObject):
+class CoursesPage(NewPageObject):
     """
     Course Page
     """

--- a/regression/pages/whitelabel/dashboard_page.py
+++ b/regression/pages/whitelabel/dashboard_page.py
@@ -2,7 +2,7 @@
 Student dashboard page.
 """
 from opaque_keys.edx.keys import CourseKey
-from edxapp_acceptance.pages.lms.dashboard import DashboardPage
+from regression.pages.whitelabel.new_dashboard import DashboardPage
 
 from regression.pages.whitelabel.const import URL_WITH_AUTH, DEFAULT_TIMEOUT
 

--- a/regression/pages/whitelabel/home_page.py
+++ b/regression/pages/whitelabel/home_page.py
@@ -1,12 +1,12 @@
 """
 LMS Home page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.whitelabel.const import URL_WITH_AUTH
 
 
-class HomePage(PageObject):
+class HomePage(NewPageObject):
     """
     LMS Home Page
     """

--- a/regression/pages/whitelabel/inactive_account.py
+++ b/regression/pages/whitelabel/inactive_account.py
@@ -1,10 +1,10 @@
 """
 Inactive account page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 
-class InactiveAccount(PageObject):
+class InactiveAccount(NewPageObject):
     """
     Inactive Account
     """

--- a/regression/pages/whitelabel/login_page.py
+++ b/regression/pages/whitelabel/login_page.py
@@ -1,13 +1,13 @@
 """
 LMS login page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.whitelabel.const import URL_WITH_AUTH
 from regression.pages.common.utils import fill_input_fields
 
 
-class LoginPage(PageObject):
+class LoginPage(NewPageObject):
     """
     Login page for LMS.
     """

--- a/regression/pages/whitelabel/logout_page.py
+++ b/regression/pages/whitelabel/logout_page.py
@@ -1,10 +1,10 @@
 """
 Logout Page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 
-class EcommerceLogoutPage(PageObject):
+class EcommerceLogoutPage(NewPageObject):
     """
     E-Commerce Logout
     """

--- a/regression/pages/whitelabel/new_dashboard.py
+++ b/regression/pages/whitelabel/new_dashboard.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+"""
+Student dashboard page.
+"""
+from regression.tests.helpers.new_page_object import NewPageObject
+
+from common.test.acceptance.pages.lms import BASE_URL
+
+
+class DashboardPage(NewPageObject):
+    """
+    Student dashboard, where the student can view
+    courses she/he has registered for.
+    """
+    url = "{base}/dashboard".format(base=BASE_URL)
+
+    def is_browser_on_page(self):
+        return self.q(css='.my-courses').present
+
+    @property
+    def current_courses_text(self):
+        """
+        This is the title label for the section of the student dashboard that
+        shows all the courses that the student is enrolled in.
+        The string displayed is defined in lms/templates/dashboard.html.
+        """
+        text_items = self.q(css='#my-courses').text
+        if len(text_items) > 0:
+            return text_items[0]
+        else:
+            return ""
+
+    @property
+    def available_courses(self):
+        """
+        Return list of the names of available courses (e.g. "999 edX Demonstration Course")
+        """
+        def _get_course_name(el):
+            return el.text
+
+        return self.q(css='h3.course-title > a').map(_get_course_name).results
+
+    @property
+    def banner_text(self):
+        """
+        Return the text of the banner on top of the page, or None if
+        the banner is not present.
+        """
+        message = self.q(css='div.wrapper-msg')
+        if message.present:
+            return message.text[0]
+        return None
+
+    def get_enrollment_mode(self, course_name):
+        """Get the enrollment mode for a given course on the dashboard.
+
+        Arguments:
+            course_name (str): The name of the course whose mode should be retrieved.
+
+        Returns:
+            String, indicating the enrollment mode for the course corresponding to
+            the provided course name.
+
+        Raises:
+            Exception, if no course with the provided name is found on the dashboard.
+        """
+        # Filter elements by course name, only returning the relevant course item
+        course_listing = self.q(css=".course").filter(lambda el: course_name in el.text).results
+
+        if course_listing:
+            # There should only be one course listing for the provided course name.
+            # Since 'ENABLE_VERIFIED_CERTIFICATES' is true in the Bok Choy settings, we
+            # can expect two classes to be present on <article> elements, one being 'course'
+            # and the other being the enrollment mode.
+            enrollment_mode = course_listing[0].get_attribute('class').split('course ')[1]
+        else:
+            raise Exception("No course named {} was found on the dashboard".format(course_name))
+
+        return enrollment_mode
+
+    def upgrade_enrollment(self, course_name, upgrade_page):
+        """Interact with the upgrade button for the course with the provided name.
+
+        Arguments:
+            course_name (str): The name of the course whose mode should be checked.
+            upgrade_page (PageObject): The page to wait on after clicking the upgrade button. Importing
+                the definition of PaymentAndVerificationFlow results in a circular dependency.
+
+        Raises:
+            Exception, if no enrollment corresponding to the provided course name appears
+                on the dashboard.
+        """
+        # Filter elements by course name, only returning the relevant course item
+        course_listing = self.q(css=".course").filter(lambda el: course_name in el.text).results
+
+        if course_listing:
+            # There should only be one course listing corresponding to the provided course name.
+            el = course_listing[0]
+
+            # Click the upgrade button
+            el.find_element_by_css_selector('#upgrade-to-verified').click()
+
+            upgrade_page.wait_for_page()
+        else:
+            raise Exception("No enrollment for {} is visible on the dashboard.".format(course_name))
+
+    def view_course(self, course_id):
+        """
+        Go to the course with `course_id` (e.g. edx/Open_DemoX/edx_demo_course)
+        """
+        link_css = self._link_css(course_id)
+
+        if link_css is not None:
+            self.q(css=link_css).first.click()
+        else:
+            msg = "No links found for course {0}".format(course_id)
+            self.warning(msg)
+
+    def _link_css(self, course_id):
+        """
+        Return a CSS selector for the link to the course with `course_id`.
+        """
+        # Get the link hrefs for all courses
+        all_links = self.q(css='a.enter-course').map(lambda el: el.get_attribute('href')).results
+
+        # Search for the first link that matches the course id
+        link_index = None
+        for index in range(len(all_links)):
+            if course_id in all_links[index]:
+                link_index = index
+                break
+
+        if link_index is not None:
+            return "a.enter-course:nth-of-type({0})".format(link_index + 1)
+        else:
+            return None
+
+    def view_course_unenroll_dialog_message(self, course_id):
+        """
+        Go to the course unenroll dialog message for `course_id` (e.g. edx/Open_DemoX/edx_demo_course)
+        """
+        div_index = self.get_course_actions_link_css(course_id)
+        button_link_css = "#actions-dropdown-link-{}".format(div_index)
+        unenroll_css = "#unenroll-{}".format(div_index)
+
+        if button_link_css is not None:
+            self.q(css=button_link_css).first.click()
+            self.wait_for_element_visibility(unenroll_css, 'Unenroll message dialog is visible.')
+            self.q(css=unenroll_css).first.click()
+            self.wait_for_ajax()
+
+            return {
+                'track-info': self.q(css='#track-info').html,
+                'refund-info': self.q(css='#refund-info').html
+            }
+
+        else:
+            msg = "No links found for course {0}".format(course_id)
+            self.warning(msg)
+
+    def get_course_actions_link_css(self, course_id):
+        """
+            Return a index for unenroll button with `course_id`.
+        """
+        # Get the link hrefs for all courses
+        all_divs = self.q(css='div.wrapper-action-more').map(lambda el: el.get_attribute('data-course-key')).results
+
+        # Search for the first link that matches the course id
+        div_index = None
+        for index in range(len(all_divs)):
+            if course_id in all_divs[index]:
+                div_index = index
+                break
+
+        return div_index
+
+    def pre_requisite_message_displayed(self):
+        """
+        Verify if pre-requisite course messages are being displayed.
+        """
+        return self.q(css='div.prerequisites > .tip').visible
+
+    def get_course_listings(self):
+        """Retrieve the list of course DOM elements"""
+        return self.q(css='ul.listing-courses')
+
+    def get_course_social_sharing_widget(self, widget_name):
+        """ Retrieves the specified social sharing widget by its classification """
+        return self.q(css='a.action-{}'.format(widget_name))
+
+    def get_profile_img(self):
+        """ Retrieves the user's profile image """
+        return self.q(css='img.user-image-frame')
+
+    def get_courses(self):
+        """
+        Get all courses shown in the dashboard
+        """
+        return self.q(css='ul.listing-courses .course-item')
+
+    def get_course_date(self):
+        """
+        Get course date of the first course from dashboard
+        """
+        return self.q(css='ul.listing-courses .course-item:first-of-type .info-date-block').first.text[0]
+
+    def click_username_dropdown(self):
+        """
+        Click username dropdown.
+        """
+        self.q(css='.user-dropdown').first.click()
+
+    @property
+    def username_dropdown_link_text(self):
+        """
+        Return list username dropdown links.
+        """
+        return self.q(css='.user-dropdown-menu li a').text
+
+    def click_my_profile_link(self):
+        """
+        Click on `Profile` link.
+        """
+        self.q(css='.user-dropdown-menu li a').nth(1).click()
+
+    def click_account_settings_link(self):
+        """
+        Click on `Account` link.
+        """
+        self.q(css='.user-dropdown-menu li a').nth(2).click()
+
+    @property
+    def language_selector(self):
+        """
+        return language selector
+        """
+        self.wait_for_element_visibility(
+            '#settings-language-value',
+            'Language selector element is available'
+        )
+        return self.q(css='#settings-language-value')

--- a/regression/pages/whitelabel/new_logistration.py
+++ b/regression/pages/whitelabel/new_logistration.py
@@ -1,0 +1,370 @@
+"""Login and Registration pages """
+
+from urllib import urlencode
+
+from bok_choy.promise import EmptyPromise, Promise
+
+from regression.tests.helpers.new_page_object import NewPageObject, unguarded
+
+from common.test.acceptance.pages.lms import BASE_URL
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
+
+
+class RegisterPage(NewPageObject):
+    """
+    Registration page (create a new account)
+    """
+
+    def __init__(self, browser, course_id):
+        """
+        Course ID is currently of the form "edx/999/2013_Spring"
+        but this format could change.
+        """
+        super(RegisterPage, self).__init__(browser)
+        self._course_id = course_id
+
+    @property
+    def url(self):
+        """
+        URL for the registration page of a course.
+        """
+        return "{base}/register?course_id={course_id}&enrollment_action={action}".format(
+            base=BASE_URL,
+            course_id=self._course_id,
+            action="enroll",
+        )
+
+    def is_browser_on_page(self):
+        return any([
+            'register' in title.lower()
+            for title in self.q(css='span.title-sub').text
+        ])
+
+    def provide_info(self, email, password, username, full_name):
+        """
+        Fill in registration info.
+        `email`, `password`, `username`, and `full_name` are the user's credentials.
+        """
+        self.wait_for_element_visibility('input#email', 'Email field is shown')
+        self.q(css='input#email').fill(email)
+        self.q(css='input#password').fill(password)
+        self.q(css='input#username').fill(username)
+        self.q(css='input#name').fill(full_name)
+        self.q(css='input#tos-yes').first.click()
+        self.q(css='input#honorcode-yes').first.click()
+        self.q(css="#country option[value='US']").first.click()
+
+    def submit(self):
+        """
+        Submit registration info to create an account.
+        """
+        self.q(css='button#submit').first.click()
+
+        # The next page is the dashboard; make sure it loads
+        dashboard = DashboardPage(self.browser)
+        dashboard.wait_for_page()
+        return dashboard
+
+
+class ResetPasswordPage(NewPageObject):
+    """Initialize the page.
+
+        Arguments:
+            browser (Browser): The browser instance.
+    """
+    url = BASE_URL + "/login#forgot-password-modal"
+
+    def is_browser_on_page(self):
+        return (
+            self.q(css="#login-anchor").is_present() and
+            self.q(css="#password-reset-anchor").is_present()
+        )
+
+    def is_form_visible(self):
+        return (
+            not self.q(css="#login-anchor").visible and
+            self.q(css="#password-reset-form").visible
+        )
+
+    def fill_password_reset_form(self, email):
+        """
+        Fill in the form and submit it
+        """
+        self.wait_for_element_visibility('#password-reset-email', 'Reset Email field is shown')
+        self.q(css="#password-reset-email").fill(email)
+        self.q(css="button.js-reset").click()
+
+    def is_success_visible(self, selector):
+        """
+        Check element is visible
+        """
+        self.wait_for_element_visibility(selector, 'Success div is shown')
+
+    def get_success_message(self):
+        """
+        Return a success message displayed to the user
+        """
+        return self.q(css=".submission-success h4").text
+
+
+class CombinedLoginAndRegisterPage(NewPageObject):
+    """Interact with combined login and registration page.
+
+    This page is currently hidden behind the feature flag
+    `ENABLE_COMBINED_LOGIN_REGISTRATION`, which is enabled
+    in the bok choy settings.
+
+    When enabled, the new page is available from either
+    `/login` or `/register`; the new page is also served at
+    `/account/login/` or `/account/register/`, where it was
+    available for a time during an A/B test.
+
+    Users can reach this page while attempting to enroll
+    in a course, in which case users will be auto-enrolled
+    when they successfully authenticate (unless the course
+    has been paywalled).
+
+    """
+    def __init__(self, browser, start_page="register", course_id=None):
+        """Initialize the page.
+
+        Arguments:
+            browser (Browser): The browser instance.
+
+        Keyword Args:
+            start_page (str): Whether to start on the login or register page.
+            course_id (unicode): If provided, load the page as if the user
+                is trying to enroll in a course.
+
+        """
+        super(CombinedLoginAndRegisterPage, self).__init__(browser)
+        self._course_id = course_id
+
+        if start_page not in ["register", "login"]:
+            raise ValueError("Start page must be either 'register' or 'login'")
+        self._start_page = start_page
+
+    @property
+    def url(self):
+        """Return the URL for the combined login/registration page. """
+        url = "{base}/{login_or_register}".format(
+            base=BASE_URL,
+            login_or_register=self._start_page
+        )
+
+        # These are the parameters that would be included if the user
+        # were trying to enroll in a course.
+        if self._course_id is not None:
+            url += "?{params}".format(
+                params=urlencode({
+                    "course_id": self._course_id,
+                    "enrollment_action": "enroll"
+                })
+            )
+
+        return url
+
+    def is_browser_on_page(self):
+        """Check whether the combined login/registration page has loaded. """
+        return (
+            self.q(css="#login-anchor").is_present() and
+            self.q(css="#register-anchor").is_present() and
+            self.current_form is not None
+        )
+
+    def toggle_form(self):
+        """Toggle between the login and registration forms. """
+        old_form = self.current_form
+
+        # Toggle the form
+        if old_form == "login":
+            self.q(css=".form-toggle[data-type='register']").click()
+        else:
+            self.q(css=".form-toggle[data-type='login']").click()
+
+        # Wait for the form to change before returning
+        EmptyPromise(
+            lambda: self.current_form != old_form,
+            "Finish toggling to the other form"
+        ).fulfill()
+
+    def register(
+            self, email="", password="", username="", full_name="", country="", favorite_movie="",
+            terms_of_service=False
+    ):
+        """Fills in and submits the registration form.
+
+        Requires that the "register" form is visible.
+        This does NOT wait for the next page to load,
+        so the caller should wait for the next page
+        (or errors if that's the expected behavior.)
+
+        Keyword Arguments:
+            email (unicode): The user's email address.
+            password (unicode): The user's password.
+            username (unicode): The user's username.
+            full_name (unicode): The user's full name.
+            country (unicode): Two-character country code.
+            terms_of_service (boolean): If True, agree to the terms of service and honor code.
+
+        """
+        # Fill in the form
+        self.wait_for_element_visibility('#register-email', 'Email field is shown')
+        if email:
+            self.q(css="#register-email").fill(email)
+        if full_name:
+            self.q(css="#register-name").fill(full_name)
+        if username:
+            self.q(css="#register-username").fill(username)
+        if password:
+            self.q(css="#register-password").fill(password)
+        if country:
+            self.q(css="#register-country option[value='{country}']".format(country=country)).click()
+        if favorite_movie:
+            self.q(css="#register-favorite_movie").fill(favorite_movie)
+        if terms_of_service:
+            self.q(css="label[for='register-honor_code']").click()
+
+        # Submit it
+        self.q(css=".register-button").click()
+
+    def login(self, email="", password=""):
+        """Fills in and submits the login form.
+
+        Requires that the "login" form is visible.
+        This does NOT wait for the next page to load,
+        so the caller should wait for the next page
+        (or errors if that's the expected behavior).
+
+        Keyword Arguments:
+            email (unicode): The user's email address.
+            password (unicode): The user's password.
+
+        """
+        # Fill in the form
+        self.wait_for_element_visibility('#login-email', 'Email field is shown')
+        self.q(css="#login-email").fill(email)
+        self.q(css="#login-password").fill(password)
+
+        # Submit it
+        self.q(css=".login-button").click()
+
+    def click_third_party_dummy_provider(self):
+        """Clicks on the Dummy third party provider login button.
+
+        Requires that the "login" form is visible.
+        This does NOT wait for the ensuing page[s] to load.
+        Only the "Dummy" provider is used for bok choy because it is the only
+        one that doesn't send traffic to external servers.
+        """
+        self.q(css="button.{}-oa2-dummy".format(self.current_form)).click()
+
+    def password_reset(self, email):
+        """Navigates to, fills in, and submits the password reset form.
+
+        Requires that the "login" form is visible.
+
+        Keyword Arguments:
+            email (unicode): The user's email address.
+
+        """
+        login_form = self.current_form
+
+        # Click the password reset link on the login page
+        self.q(css=".forgot-password").click()
+
+        # Wait for the password reset form to load
+        EmptyPromise(
+            lambda: self.current_form != login_form,
+            "Finish toggling to the password reset form"
+        ).fulfill()
+
+        # Fill in the form
+        self.wait_for_element_visibility('#password-reset-email', 'Email field is shown')
+        self.q(css="#password-reset-email").fill(email)
+
+        # Submit it
+        self.q(css="button.js-reset").click()
+
+        return CombinedLoginAndRegisterPage(self.browser).wait_for_page()
+
+    @property
+    @unguarded
+    def current_form(self):
+        """Return the form that is currently visible to the user.
+
+        Returns:
+            Either "register", "login", or "password-reset" if a valid
+            form is loaded.
+
+            If we can't find any of these forms on the page, return None.
+
+        """
+        if self.q(css=".register-button").visible:
+            return "register"
+        elif self.q(css=".login-button").visible:
+            return "login"
+        elif self.q(css=".js-reset").visible:
+            return "password-reset"
+        elif self.q(css=".proceed-button").visible:
+            return "hinted-login"
+
+    @property
+    def email_value(self):
+        """ Current value of the email form field """
+        return self.q(css="#register-email").attrs('value')[0]
+
+    @property
+    def full_name_value(self):
+        """ Current value of the full_name form field """
+        return self.q(css="#register-name").attrs('value')[0]
+
+    @property
+    def username_value(self):
+        """ Current value of the username form field """
+        return self.q(css="#register-username").attrs('value')[0]
+
+    @property
+    def errors(self):
+        """Return a list of errors displayed to the user. """
+        return self.q(css=".submission-error li").text
+
+    def wait_for_errors(self):
+        """Wait for errors to be visible, then return them. """
+        def _check_func():
+            """Return success status and any errors that occurred."""
+            errors = self.errors
+            return (bool(errors), errors)
+        return Promise(_check_func, "Errors are visible").fulfill()
+
+    @property
+    def success(self):
+        """Return a success message displayed to the user."""
+        if self.q(css=".submission-success").visible:
+            return self.q(css=".submission-success h4").text
+
+    def wait_for_success(self):
+        """Wait for a success message to be visible, then return it."""
+        def _check_func():
+            """Return success status and any errors that occurred."""
+            success = self.success
+            return (bool(success), success)
+        return Promise(_check_func, "Success message is visible").fulfill()
+
+    @unguarded  # Because we go from this page -> temporary page -> this page again when testing the Dummy provider
+    def wait_for_auth_status_message(self):
+        """Wait for a status message to be visible following third_party registration, then return it."""
+        def _check_func():
+            """Return third party auth status notice message."""
+            selector = '.js-auth-warning div'
+            msg_element = self.q(css=selector)
+            if msg_element.visible:
+                return (True, msg_element.text[0])
+            return (False, None)
+        return Promise(_check_func, "Result of third party auth is visible").fulfill()
+
+    @property
+    def hinted_login_prompt(self):
+        """Get the message displayed to the user on the hinted-login form"""
+        if self.q(css=".wrapper-other-login .instructions").visible:
+            return self.q(css=".wrapper-other-login .instructions").text[0]

--- a/regression/pages/whitelabel/profile_page.py
+++ b/regression/pages/whitelabel/profile_page.py
@@ -1,10 +1,10 @@
 """
 User profile page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 
-class ProfilePage(PageObject):
+class ProfilePage(NewPageObject):
     """
     Student profile
     """

--- a/regression/pages/whitelabel/receipt_page.py
+++ b/regression/pages/whitelabel/receipt_page.py
@@ -1,7 +1,7 @@
 """
 Receipt page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.common.utils import (
     convert_date_format,
@@ -9,7 +9,7 @@ from regression.pages.common.utils import (
 )
 
 
-class ReceiptPage(PageObject):
+class ReceiptPage(NewPageObject):
     """
     Course receipt page
     """

--- a/regression/pages/whitelabel/redeem_coupon_page.py
+++ b/regression/pages/whitelabel/redeem_coupon_page.py
@@ -1,7 +1,7 @@
 """
 Redeem coupon page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 from opaque_keys.edx.keys import AssetKey
 
 from regression.pages.whitelabel.const import ECOMMERCE_URL_WITH_AUTH
@@ -25,7 +25,7 @@ def get_course_ids_from_link(link):
     return AssetKey.from_string(asset_str).course_key
 
 
-class RedeemCouponPage(PageObject):
+class RedeemCouponPage(NewPageObject):
     """
     Redeem Coupon page
     """
@@ -191,7 +191,7 @@ class RedeemCouponPage(PageObject):
         )
 
 
-class RedeemCouponErrorPage(PageObject):
+class RedeemCouponErrorPage(NewPageObject):
     """
     Redeem Coupon Error page
     """

--- a/regression/pages/whitelabel/registration_page.py
+++ b/regression/pages/whitelabel/registration_page.py
@@ -2,7 +2,7 @@
 Registration page.
 """
 
-from edxapp_acceptance.pages.lms.login_and_register import (
+from regression.pages.whitelabel.new_logistration import (
     CombinedLoginAndRegisterPage
 )
 from edxapp_acceptance.tests.helpers import disable_animations

--- a/regression/pages/whitelabel/reset_password_page.py
+++ b/regression/pages/whitelabel/reset_password_page.py
@@ -1,12 +1,12 @@
 """
 Reset Password page
 """
-from bok_choy.page_object import PageObject
+from regression.tests.helpers.new_page_object import NewPageObject
 
 from regression.pages.whitelabel.const import URL_WITH_AUTH
 
 
-class ResetPassword(PageObject):
+class ResetPassword(NewPageObject):
     """
     Reset password
     """
@@ -41,7 +41,7 @@ class ResetPassword(PageObject):
             self.q(css='.action.action-primary.action-update.js-reset').click()
 
 
-class ResetPasswordComplete(PageObject):
+class ResetPasswordComplete(NewPageObject):
     """
     Reset password completion page
     """

--- a/regression/tests/helpers/new_page_object.py
+++ b/regression/tests/helpers/new_page_object.py
@@ -1,0 +1,67 @@
+from bok_choy.page_object import PageObject, unguarded
+from bok_choy.promise import Promise, EmptyPromise, BrokenPromise
+
+
+
+class NewPageObject(PageObject):
+
+
+    @unguarded
+    def wait_for_page(self, timeout=30):
+        """
+        Block until the page loads, then returns the page.
+        Useful for ensuring that we navigate successfully to a particular page.
+
+        Keyword Args:
+            timeout (int): The number of seconds to wait for the page before timing out with an exception.
+
+        Raises:
+            BrokenPromise: The timeout is exceeded without the page loading successfully.
+        """
+
+        def _is_document_interactive():
+            """
+            Check the loading state of the document to ensure the document is
+            in interactive mode
+            """
+            return self.browser.execute_script(
+                "return document.readyState=='interactive'")
+
+
+        def _is_document_ready():
+            """
+            Check the loading state of the document to ensure the document and all sub-resources
+            have finished loading (the document load event has been fired.)
+            """
+            return self.browser.execute_script(
+                "return document.readyState=='complete'")
+
+        # Wait for page to laod completely i.e. for document.readyState to
+        # become complete
+
+        try:
+            EmptyPromise(
+                _is_document_ready,
+                "The document and all sub-resources have finished loading.",
+                timeout=timeout
+            ).fulfill()
+        except BrokenPromise:
+
+            # If document.readyState does not become complete after a specific
+            # time relax the condition and check for the state to become
+            # interactive
+            EmptyPromise(
+                _is_document_interactive,
+                "The document is in interactive mode.",
+                timeout=timeout
+            ).fulfill()
+
+        result = Promise(
+            lambda: (self.is_browser_on_page(), self), "loaded page {!r}".format(self),
+            timeout=timeout
+        ).fulfill()
+
+        if self.verify_accessibility:
+            self.a11y_audit.check_for_accessibility_errors()  # pylint: disable=no-member
+
+        return result


### PR DESCRIPTION
Recently we have seen a lot of e2e and microsites test failures with the following message

*BrokenPromise: Promise not satisfied: The document and all sub-resources have finished loading.*

Upon investigating we found out that on stage the page is loaded but somehow the third party requests(there are a lot of requests sent to optimizely, google analytics etc.) get stuck and since the wait for page relies on the document.readyState to become "ready" it throws and error and the test is considered as failure.

I have used an experimental approach where we added an additional check if document does not reach the ready state, instead of throwing error we check if document.readyState="interactive", if so we continue with the test instead of throwing error.

I think this approach can take care of these errors where page is loaded but error is raised due to some third party call getting stuck.

The actual change would have to be done in bok-choy code itself, I have just inherited the class from bok-choy in changed it in my repo so we could also test it's impact.

[WL-1435](https://openedx.atlassian.net/browse/WL-1435)
