### PR TITLE
Restore the devstack_env file as it is used by the devstack repo's Makefile

### DIFF
--- a/devstack_env
+++ b/devstack_env
@@ -1,0 +1,26 @@
+# Docker Devstack environment variables
+# Loaded via "docker run --env-file devstack_env ..."
+# For example this is what the edx/devstack repo uses
+# in its Makefile.
+
+ACCESS_TOKEN=
+BASIC_AUTH_USER=
+BASIC_AUTH_PASSWORD=
+CONFIG_ROOT=/edx/app/e2e
+USER_LOGIN_EMAIL=staff@example.com
+USER_LOGIN_PASSWORD=edx
+COURSE_ORG=edX
+COURSE_NUMBER=E2E-101
+COURSE_RUN=course
+COURSE_DISPLAY_NAME=Manual Smoke Test Course 1 - Auto
+EDXAPP_CMS_DOC_LINK_BASE_URL=http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
+GLOBAL_PASSWORD=
+LMS_BASE_URL=edx.devstack.lms:18000
+LMS_PROTOCOL=http
+SELENIUM_BROWSER=chrome
+SELENIUM_HOST=edx.devstack.chrome
+SELENIUM_PORT=4444
+STAFF_USER_EMAIL=
+STUDIO_BASE_URL=edx.devstack.studio:18010
+STUDIO_PROTOCOL=http
+VIRTUAL_ENV=/edx/app/e2e/venvs/e2e


### PR DESCRIPTION
@bmedx looks like this is a tricky cross-repo dependency/assumption.
See: https://github.com/edx/devstack/blob/master/Makefile#L174