### PR TITLE
e2e for sandbox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,33 +165,72 @@ To update page objects installed from external repos:
 How to run Whitelabel tests
 ----------------------------
 
-Before running whitelabel tests please ensure that these environment variables are set.
+1. Create a virtual environment for installation/executing tests.
+
+
+2. Change your working directory to `edx-e2e-tests`.
 
 .. code:: bash
 
+    cd edx-e2e-tests/
+
+3. Install the requirements
+
+.. code:: bash
+
+    pip install -r requirements/base.txt
+
+4. Install the page objects for the application from the edx platform repo. This will
+   clone the entire repo into lib/edx-platform so that it can use the page objects and
+   helper methods from common/test/acceptance. We also install capa and xmodule into the
+   virtual environment from common/lib.
+
+
+.. code:: bash
+
+    paver install_pages
+
+5. Set these Environment variables
+
+.. code:: bash
+
+    ==> TEST_ENV (Only required if tests are not running on stage, e.g. for sandbox just assign value `sandbox')
+    ==> TARGET_DNS (Only required if tests are not running on stage, just provide DNS e.g. just provide "helio" for "https://mitxpro-helio.sandbox.edx.org")
+    ==> ORG (Only valid values for now are "MITxPRO" and "HarvardMedGlobalAcademy", if not provided the tests wil run against MITxPRO by default)
     ==> BASIC_AUTH_USER
     ==> BASIC_AUTH_PASSWORD
-    ==> USER_LOGIN_EMAIL
-    ==> USER_LOGIN_PASSWORD
-    ==> COURSE_RUN
-    ==> COURSE_DISPLAY_NAME
-    ==> COURSE_NUMBER
-    ==> COURSE_ORG
     ==> GLOBAL_PASSWORD
-    ==> STAFF_USER_EMAIL
-    ==> TEST_EMAIL_SERVICE
-    ==> TEST_EMAIL_ACCOUNT
-    ==> TEST_EMAIL_PASSWORD
-    ==> ACCESS_TOKEN
+    ==> OAUTH_CLIENT_ID (Only required for stage or sandbox is not using the default id)
+    ==> OAUTH_CLIENT_SECRET (Only required for stage or sandbox is not using the default secret)
+    ==> COURSE_RUN (Optional, use only if you are using a value other than default)
+    ==> COURSE_DISPLAY_NAME (Optional, use only if you are using a value other than default)
+    ==> COURSE_NUMBER (Optional, use only if you are using a value other than default)
+    ==> COURSE_ORG (Optional, use only if you are using a value other than specified in ORG var)
 
 
 To run all the tests in the file:
 
 .. code:: bash
 
-    paver e2e_wl_test whitelabel/test_user_account.py
+    paver e2e_wl_test
 
-NOTE: In order to run tests in a particular class or a single test, use the same Nose specifiers as mentioned in the above section. However, do not forget to change the paver target to e2e_wl_test
+To run all the tests in the file:
+
+.. code:: bash
+
+    paver e2e_wl_test test_otto_enrollment.py
+
+To run all the tests in a particular class:
+
+.. code:: bash
+
+    paver e2e_wl_test test_misc.py:TestMisc
+
+To run a single test:
+
+.. code:: bash
+
+    paver e2e_wl_test test_misc.py:TestMisc.test_logos
 
 
 Where and How to add new tests

--- a/jenkins/white_label.sh
+++ b/jenkins/white_label.sh
@@ -27,7 +27,7 @@ paver install_pages > log/paver_install_pages.log
 
 
 # Run the tests
-organizations="HarvardMedGlobalAcademy MITxPRO"
+organizations="MITxPRO HarvardMedGlobalAcademy"
 
 for organization in ${organizations}; do
     export ORG=${organization}

--- a/pavement.py
+++ b/pavement.py
@@ -126,10 +126,7 @@ def wl_test_config():
 
     # Make sure environment variables are set.
     env_vars = [
-        'STAFF_USER_EMAIL',
-        'GLOBAL_PASSWORD',
-        'OAUTH_CLIENT_ID',
-        'OAUTH_CLIENT_SECRET'
+        'GLOBAL_PASSWORD'
         ]
     for env_var in env_vars:
         try:

--- a/regression/pages/__init__.py
+++ b/regression/pages/__init__.py
@@ -5,6 +5,7 @@ which later on are used by pages inside pages package.
 
 import os
 
+
 BASIC_AUTH_USERNAME = os.environ.get('BASIC_AUTH_USER', 'not_set')
 BASIC_AUTH_PASSWORD = os.environ.get('BASIC_AUTH_PASSWORD', 'not_set')
 

--- a/regression/pages/whitelabel/__init__.py
+++ b/regression/pages/whitelabel/__init__.py
@@ -1,0 +1,85 @@
+"""
+Some environment vars for WL tests
+Here we are finalizing the target url based on test environment and org
+"""
+
+import os
+
+from datetime import datetime
+
+from regression.pages import BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD
+
+
+# Specify environment if stage is not used
+DEFAULT_ENV = "stage"
+TEST_ENV = os.environ.get("TEST_ENV", DEFAULT_ENV)
+
+# Select the Org for which to run the tests
+DEFAULT_ORG = 'MITxPRO'
+
+ORG = os.environ.get('ORG', DEFAULT_ORG)
+
+SANDBOX_ECOM_PREFIX = "ecommerce-"
+STAGE_ECOM_PREFIX = "payments."
+
+BASE_URL = ""
+ECOM_PREFIX = ""
+
+if TEST_ENV == DEFAULT_ENV:
+    BASE_URLS = {
+        'edX': u'courses.stage.edx.org',
+        'HarvardMedGlobalAcademy': u'globalacademy-stage.hms.harvard.edu',
+        'MITxPRO': u'stage.MITxPRO.mit.edu'
+    }
+
+    BASE_URL = BASE_URLS[ORG]
+    ECOM_PREFIX = STAGE_ECOM_PREFIX
+
+elif TEST_ENV == "sandbox":
+    # Get DNS name if tests are running on sandbox
+    TARGET_DNS = os.environ.get("TARGET_DNS")
+    BASE_URLS = {
+        'MITxPRO': "mitxpro-{}.sandbox.edx.org".format(TARGET_DNS),
+        'Harvard': "hms-{}.sandbox.edx.org".format(TARGET_DNS)
+    }
+    BASE_URL = BASE_URLS[ORG]
+    ECOM_PREFIX = SANDBOX_ECOM_PREFIX
+
+
+LMS_PROTOCOL = os.environ.get('LMS_PROTOCOL', 'https')
+
+
+LMS_URL = '{}://{}'.format(LMS_PROTOCOL, BASE_URL)
+ECOM_URL = '{}://{}{}'.format(
+    LMS_PROTOCOL,
+    ECOM_PREFIX,
+    BASE_URL
+)
+
+if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD:
+    LMS_URL_WITH_AUTH = '{}://{}:{}@{}'.format(
+        LMS_PROTOCOL, BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, BASE_URL
+    )
+    ECOM_URL_WITH_AUTH = '{}://{}:{}@{}{}'.format(
+        LMS_PROTOCOL,
+        BASIC_AUTH_USERNAME,
+        BASIC_AUTH_PASSWORD,
+        ECOM_PREFIX,
+        BASE_URL
+    )
+else:
+    LMS_URL_WITH_AUTH = '{}://{}'.format(LMS_PROTOCOL, BASE_URL)
+    ECOM_URL_WITH_AUTH = '{}://{}{}'.format(
+        LMS_PROTOCOL,
+        ECOM_PREFIX,
+        BASE_URL
+    )
+
+
+# Get Course ID, Price and Name
+DEFAULT_COURSE_NUM = "WL_E2E"
+DEFAULT_COURSE_RUN = str(datetime.now().year)
+COURSE_ORG = os.environ.get("COURSE_ORG", ORG)
+COURSE_NUMBER = os.environ.get("COURSE_NUMBER", DEFAULT_COURSE_NUM)
+COURSE_RUN = os.environ.get("COURSE_RUN", DEFAULT_COURSE_RUN)
+DEFAULT_COURSE_PRICE = 167.0

--- a/regression/pages/whitelabel/basket_page.py
+++ b/regression/pages/whitelabel/basket_page.py
@@ -1,9 +1,10 @@
 """
 Pages for single course and multi course purchase baskets
 """
+import os
 from bok_choy.page_object import PageObject
 
-from regression.pages.whitelabel.const import ECOMMERCE_URL_WITH_AUTH
+from regression.pages.whitelabel import ECOM_URL_WITH_AUTH
 
 from regression.pages.common.utils import (
     extract_numerical_value_from_price_string,
@@ -17,7 +18,7 @@ class BasketPage(PageObject):
     Generic class for E-Commerce basket pages
     """
 
-    url = ECOMMERCE_URL_WITH_AUTH + 'basket'
+    url = os.path.join(ECOM_URL_WITH_AUTH, 'basket')
 
     def is_browser_on_page(self):
         return self.q(css='#basket-total .price').visible
@@ -175,7 +176,6 @@ class SingleSeatBasketPage(BasketPage):
         Arguments:
              coupon_code(str): The coupon to apply.
         """
-        self.q(css='#voucher_form_link').click()
         self.wait_for_element_visibility(
             '#voucher_form',
             'Wait for Voucher form to display'

--- a/regression/pages/whitelabel/const.py
+++ b/regression/pages/whitelabel/const.py
@@ -3,66 +3,37 @@
 List of constants to be used throughout the tests
 """
 import os
-from regression.pages import BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD
+
+from regression.pages.whitelabel import (
+    LMS_URL,
+    ECOM_URL,
+    ORG
+)
 
 # Global password
 PASSWORD = os.environ.get('GLOBAL_PASSWORD')
 
 # Client information for access token
-OAUTH_CLIENT_ID = os.environ.get('OAUTH_CLIENT_ID')
-OAUTH_CLIENT_SECRET = os.environ.get('OAUTH_CLIENT_SECRET')
-
-BASIC_AUTH = BASIC_AUTH_USERNAME + ":" + BASIC_AUTH_PASSWORD + "@"
-
-# Select the Org for which to run the tests
-DEFAULT_ORG = 'HarvardMedGlobalAcademy'
-
-ORG = os.environ.get('ORG', DEFAULT_ORG)
+SANDBOX_CLIENT_ID = "ecommerce-key"
+OAUTH_CLIENT_ID = os.environ.get('OAUTH_CLIENT_ID', SANDBOX_CLIENT_ID)
+SANDBOX_CLIENT_SECRET = "ecommerce-secret"
+OAUTH_CLIENT_SECRET = os.environ.get(
+    'OAUTH_CLIENT_SECRET',
+    SANDBOX_CLIENT_SECRET
+)
 
 # Organization Based Settings
 ##############################################################################
-# E-commerce raw url
-RAW_ECOMMERCE_URL = {
-    'HarvardMedGlobalAcademy':
-        u'https://{}payments.globalacademy-stage.hms.harvard.edu/',
-    'HarvardXPLUS': u'https://{}stage-payments.harvardxplus.harvard.edu/',
-    'MITxPRO': u'https://{}payments.stage.mitxpro.mit.edu/'
-}
 
-# BASIC raw URL
-RAW_URL = {
-    'HarvardMedGlobalAcademy':
-        u'https://{}globalacademy-stage.hms.harvard.edu/',
-    'HarvardXPLUS': u'https://{}stage-courses.harvardxplus.harvard.edu/',
-    'MITxPRO': u'https://{}stage.mitxpro.mit.edu/'
-}
+ECOMMERCE_API_URL = os.path.join(ECOM_URL, 'api/v2/')
 
-# E-commerce urls
-ECOMMERCE_URL_WITHOUT_AUTH = RAW_ECOMMERCE_URL[ORG].format("")
-
-ECOMMERCE_URL_WITH_AUTH = RAW_ECOMMERCE_URL[ORG].format(BASIC_AUTH)
-
-# BASIC URLs
-URL_WITHOUT_AUTH = RAW_URL[ORG].format("")
-
-URL_WITH_AUTH = RAW_URL[ORG].format(BASIC_AUTH)
-
-ECOMMERCE_API_URL = ECOMMERCE_URL_WITHOUT_AUTH + 'api/v2/'
-
-ENROLLMENT_API_URL = URL_WITHOUT_AUTH + 'api/enrollment/v1'
+ENROLLMENT_API_URL = os.path.join(LMS_URL, 'api/enrollment/v1')
 
 CYBERSOURCE_CHECKOUT_URL = \
     u'https://testsecureacceptance.cybersource.com/checkout'
 
-PROF_COURSE_ID = u'course-v1:{}+E2E+2018'.format(ORG)
-
-PROF_COURSE_TITLE = u'{}-E2E-Test'.format(ORG)
-
-PROF_COURSE_PRICE = 167.0
-
 EMAIL_SENDER_ACCOUNTS = {
     'HarvardMedGlobalAcademy': 'globalacademy@hms.harvard.edu',
-    'HarvardXPLUS': 'hxplus-support@edx.org',
     'MITxPRO': 'mitxpro@mit.edu',
 }
 
@@ -70,7 +41,6 @@ EMAIL_SENDER_ACCOUNT = EMAIL_SENDER_ACCOUNTS[ORG]
 
 LOGO_LINKS = {
     'HarvardMedGlobalAcademy': 'hms-logo',
-    'HarvardXPLUS': 'harvardX-logo',
     'MITxPRO': 'mitx-pro-logo'
 }
 
@@ -78,7 +48,6 @@ LOGO_LINK = LOGO_LINKS[ORG]
 
 LOGO_ALT_TEXTS = {
     'HarvardMedGlobalAcademy': 'HMS Logo',
-    'HarvardXPLUS': 'HarvardX Logo',
     'MITxPRO': 'MIT Logo'
 }
 
@@ -91,10 +60,6 @@ SOCIAL_MEDIA_LINKS = {
         'https://www.linkedin.com/company/harvard-medical-school-global-'
         'education',
         'https://instagram.com/harvardmed/?hl=en'
-    ],
-    'HarvardXPLUS': [
-        'https://www.facebook.com/HarvardX-187429968296722/',
-        'https://twitter.com/harvardonline'
     ],
     'MITxPRO': []
 }
@@ -140,10 +105,10 @@ BILLING_INFO = {
 }
 
 # Existing user email
-EXISTING_USER_EMAIL = 'wl_smoke_user01@example.com'
+# EXISTING_USER_EMAIL = 'wl_smoke_user01@example.com'
 
 # Staff user email
-STAFF_EMAIL = os.environ['STAFF_USER_EMAIL']
+# STAFF_EMAIL = os.environ['STAFF_USER_EMAIL']
 
 # Student user email
 VISUAL_USER_EMAIL = 'wl_visual_test01@example.com'
@@ -184,9 +149,9 @@ SAMPLE_LANGUAGES = [
     u'Tonga (Tonga Islands)'
 ]
 
-SELECTED_COUNTRY = u'Pakistan'
+SELECTED_COUNTRY = u'United States of America'
 
-SELECTED_LANGUAGE = u'Urdu'
+SELECTED_LANGUAGE = u'English'
 
 UNUSED_REGISTRATION_FIELDS_MAPPING = {
     "MITxPRO": ["profession", "specialty"],
@@ -195,7 +160,6 @@ UNUSED_REGISTRATION_FIELDS_MAPPING = {
         'gender',
         'company',
         'title',
-        'year_of_birth',
         'honor_code'
     ]
 }

--- a/regression/pages/whitelabel/course_about_page.py
+++ b/regression/pages/whitelabel/course_about_page.py
@@ -1,9 +1,11 @@
 """
 Course About page
 """
+import os
+
 from bok_choy.page_object import PageObject
 
-from regression.pages.whitelabel.const import URL_WITH_AUTH
+from regression.pages.whitelabel import LMS_URL_WITH_AUTH
 
 
 class CourseAboutPage(PageObject):
@@ -23,7 +25,8 @@ class CourseAboutPage(PageObject):
         """
         Construct url for the page.
         """
-        return URL_WITH_AUTH + u"courses/" + self.course_id + u"/about"
+        partial_url_str = u"courses/" + self.course_id + u"/about"
+        return os.path.join(LMS_URL_WITH_AUTH, partial_url_str)
 
     def is_browser_on_page(self):
         return all(

--- a/regression/pages/whitelabel/courses_page.py
+++ b/regression/pages/whitelabel/courses_page.py
@@ -1,9 +1,11 @@
 """
 Courses page
 """
+import os
+
 from bok_choy.page_object import PageObject
 
-from regression.pages.whitelabel.const import URL_WITH_AUTH
+from regression.pages.whitelabel import LMS_URL_WITH_AUTH
 
 
 class CoursesPage(PageObject):
@@ -11,7 +13,7 @@ class CoursesPage(PageObject):
     Course Page
     """
 
-    url = URL_WITH_AUTH + 'courses'
+    url = os.path.join(LMS_URL_WITH_AUTH, 'courses')
 
     def is_browser_on_page(self):
         return self.q(css='.course-name .course-title').visible

--- a/regression/pages/whitelabel/dashboard_page.py
+++ b/regression/pages/whitelabel/dashboard_page.py
@@ -1,10 +1,13 @@
 """
 Student dashboard page.
 """
+import os
+
 from opaque_keys.edx.keys import CourseKey
 from edxapp_acceptance.pages.lms.dashboard import DashboardPage
 
-from regression.pages.whitelabel.const import URL_WITH_AUTH, DEFAULT_TIMEOUT
+from regression.pages.whitelabel import LMS_URL_WITH_AUTH
+from regression.pages.whitelabel.const import DEFAULT_TIMEOUT
 
 
 class DashboardPageExtended(DashboardPage):
@@ -12,7 +15,7 @@ class DashboardPageExtended(DashboardPage):
     This class is an extended class of Dashboard Page,
     where we add methods that are different or not used in DashboardPage
     """
-    url = URL_WITH_AUTH + u'dashboard'
+    url = os.path.join(LMS_URL_WITH_AUTH, u'dashboard')
 
     def logout_lms(self):
         """

--- a/regression/pages/whitelabel/home_page.py
+++ b/regression/pages/whitelabel/home_page.py
@@ -3,14 +3,14 @@ LMS Home page
 """
 from bok_choy.page_object import PageObject
 
-from regression.pages.whitelabel.const import URL_WITH_AUTH
+from regression.pages.whitelabel import LMS_URL_WITH_AUTH
 
 
 class HomePage(PageObject):
     """
     LMS Home Page
     """
-    url = URL_WITH_AUTH
+    url = LMS_URL_WITH_AUTH
 
     def is_browser_on_page(self):
         """

--- a/regression/pages/whitelabel/login_page.py
+++ b/regression/pages/whitelabel/login_page.py
@@ -1,9 +1,11 @@
 """
 LMS login page
 """
+import os
+
 from bok_choy.page_object import PageObject
 
-from regression.pages.whitelabel.const import URL_WITH_AUTH
+from regression.pages.whitelabel import LMS_URL_WITH_AUTH
 from regression.pages.common.utils import fill_input_fields
 
 
@@ -11,7 +13,7 @@ class LoginPage(PageObject):
     """
     Login page for LMS.
     """
-    url = URL_WITH_AUTH + 'login'
+    url = os.path.join(LMS_URL_WITH_AUTH, 'login')
 
     def is_browser_on_page(self):
         return self.q(css='.form-toggle[data-type="register"]').visible

--- a/regression/pages/whitelabel/profile_page.py
+++ b/regression/pages/whitelabel/profile_page.py
@@ -36,7 +36,7 @@ class ProfilePage(PageObject):
         """
         self.q(
             css='.u-field.u-field-dropdown.u-field-country.'
-            'editable-toggle.mode-display'
+            'editable-toggle'
         ).click()
         self.wait_for_element_presence(
             '.u-field.u-field-dropdown.u-field-country.'
@@ -69,7 +69,7 @@ class ProfilePage(PageObject):
         """
         self.q(
             css='.u-field.u-field-dropdown.u-field-language_proficiencies.'
-            'editable-toggle.mode-display'
+            'editable-toggle'
         ).click()
         self.wait_for_element_presence(
             '.u-field.u-field-dropdown.u-field-language_proficiencies.'

--- a/regression/pages/whitelabel/redeem_coupon_page.py
+++ b/regression/pages/whitelabel/redeem_coupon_page.py
@@ -1,10 +1,12 @@
 """
 Redeem coupon page
 """
+import os
+
 from bok_choy.page_object import PageObject
 from opaque_keys.edx.keys import AssetKey
 
-from regression.pages.whitelabel.const import ECOMMERCE_URL_WITH_AUTH
+from regression.pages.whitelabel import ECOM_URL_WITH_AUTH
 from regression.pages.common.utils import (
     extract_mmm_dd_yyyy_date_string_from_text,
     convert_date_format,
@@ -43,11 +45,8 @@ class RedeemCouponPage(PageObject):
         """
         Construct a URL to the page using the coupon code.
         """
-        return (
-            ECOMMERCE_URL_WITH_AUTH +
-            'coupons/offer/?code=' +
-            self.coupon_code
-        )
+        partial_url_string = 'coupons/offer/?code=' + self.coupon_code
+        return os.path.join(ECOM_URL_WITH_AUTH, partial_url_string)
 
     def is_browser_on_page(self):
         return all(

--- a/regression/pages/whitelabel/registration_page.py
+++ b/regression/pages/whitelabel/registration_page.py
@@ -1,12 +1,13 @@
 """
 Registration page.
 """
+import os
 
 from edxapp_acceptance.pages.lms.login_and_register import (
     CombinedLoginAndRegisterPage
 )
 from edxapp_acceptance.tests.helpers import disable_animations
-from regression.pages.whitelabel.const import ORG, URL_WITH_AUTH
+from regression.pages.whitelabel import ORG, LMS_URL_WITH_AUTH
 from regression.tests.helpers.utils import (
     click_checkbox,
     fill_input_fields,
@@ -20,7 +21,7 @@ class RegisterPageExtended(CombinedLoginAndRegisterPage):
     This class is an extended class of Register Page,
     where we add methods that are different or not used in Register Page
     """
-    url = URL_WITH_AUTH + "register"
+    url = os.path.join(LMS_URL_WITH_AUTH, "register")
 
     def register_white_label_user(self, registration_fields, submit=True):
         """

--- a/regression/pages/whitelabel/reset_password_page.py
+++ b/regression/pages/whitelabel/reset_password_page.py
@@ -1,9 +1,11 @@
 """
 Reset Password page
 """
+import os
+
 from bok_choy.page_object import PageObject
 
-from regression.pages.whitelabel.const import URL_WITH_AUTH
+from regression.pages.whitelabel import LMS_URL_WITH_AUTH
 
 
 class ResetPassword(PageObject):
@@ -46,7 +48,7 @@ class ResetPasswordComplete(PageObject):
     Reset password completion page
     """
 
-    url = URL_WITH_AUTH + u'password_reset_complete'
+    url = os.path.join(LMS_URL_WITH_AUTH, u'password_reset_complete')
 
     def is_browser_on_page(self):
         return self.q(css='.status.submission-success').present

--- a/regression/tests/helpers/coupon_consts.py
+++ b/regression/tests/helpers/coupon_consts.py
@@ -74,14 +74,6 @@ VOUCHER_TYPE = {
 
 BENEFIT_VALUE = {'fixed': 60, 'per': 40}
 
-STOCK_RECORD_IDS = {
-    'HarvardMedGlobalAcademy': [24931],
-    'HarvardXPLUS': [8396],
-    'MITxPRO': [24930],
-}
-
-STOCK_RECORD_ID = STOCK_RECORD_IDS[ORG]
-
 INVALID_DOMAIN_USERS = {
     'coupon_user_06': 'wl_coupon_user06@emaildomainsix.com',
     'coupon_user_07': 'wl_coupon_user07@emaildomainseven.com'

--- a/regression/tests/helpers/utils.py
+++ b/regression/tests/helpers/utils.py
@@ -42,6 +42,25 @@ def get_course_info():
     }
 
 
+def get_wl_course_info(org, num, run):
+    """
+    Returns the course info of the course that we use for
+    the wl regression tests.
+    Arguments:
+        org
+        num
+        run
+    Returns:
+        Course Info
+    """
+    return {
+        'course_org': org,
+        'course_num': num,
+        'course_run': run,
+        'display_name': "{}-{}-Test".format(org, num)
+    }
+
+
 def get_course_display_name():
     """
     Returns the course info of the course that we use for
@@ -53,6 +72,8 @@ def get_course_display_name():
 def visit_all(pages):
     """
     Visit each page object in `pages` (an iterable).
+    Arguments:
+        pages:
     """
     for page in pages:
         print "Visiting: {}".format(page)
@@ -62,6 +83,9 @@ def visit_all(pages):
 def get_url(url_path, course_info):
     """
     Construct a URL to the page within the course.
+    Arguments:
+        url_path:
+        course_info:
     """
     course_key = get_course_key(course_info)
     return "/".join([LOGIN_BASE_URL, url_path, unicode(course_key)])
@@ -69,6 +93,9 @@ def get_url(url_path, course_info):
 
 def get_data_locator(page):
     """
+    Get Data locator
+    Arguments:
+        page:
     Returns:
         Unique data locator for the component
     """
@@ -78,6 +105,9 @@ def get_data_locator(page):
 
 def get_data_id_of_component(page):
     """
+    Get data id of component
+    Arguments:
+        page
     Returns:
         ID for the component
     """
@@ -165,11 +195,12 @@ def select_drop_down_values(page, elements_and_values_dict):
             drop down elements(css) and values.
     """
     for element, val in elements_and_values_dict.iteritems():
+        target_css = 'select[name={}] option[value="{}"]'.format(element, val)
         page.wait_for_element_visibility(
-            'select[name={}]'.format(element), 'Drop down is visible')
-        page.q(
-            css='select[name={}] option[value="{}"]'.format(element, val)
-        ).click()
+            target_css,
+            'target value is visible in Drop down'
+        )
+        page.q(css=target_css).click()
 
 
 def click_checkbox(page, checkbox_css, toggle=False):

--- a/regression/tests/whitelabel/course_enrollment_test.py
+++ b/regression/tests/whitelabel/course_enrollment_test.py
@@ -6,7 +6,6 @@ import datetime
 from bok_choy.promise import EmptyPromise
 
 from regression.pages.whitelabel.basket_page import (
-    BasketPage,
     CyberSourcePage,
     MultiSeatBasketPage,
     SingleSeatBasketPage
@@ -45,7 +44,6 @@ class CourseEnrollmentTest(WhiteLabelTestsBaseClass):
         self.lms_api_client = LmsApiClient()
         self.enrollment_api_client = EnrollmentApiClient()
         # Initialize all page objects
-        self.basket_page = BasketPage(self.browser)
         self.cyber_source_page = CyberSourcePage(self.browser)
         self.courses_page = CoursesPage(self.browser)
         self.multi_seat_basket_page = MultiSeatBasketPage(self.browser)
@@ -91,7 +89,7 @@ class CourseEnrollmentTest(WhiteLabelTestsBaseClass):
             course_about_page.click_on_single_seat_basket()
             self.single_seat_basket_page.wait_for_page()
         # Verify course name, course price and total price on basket page
-        self.verify_course_name_on_basket()
+        # self.verify_course_name_on_basket()
         self.verify_price_on_basket()
 
     def verify_course_name_on_basket(self):

--- a/regression/tests/whitelabel/test_dynamic_discount_coupon.py
+++ b/regression/tests/whitelabel/test_dynamic_discount_coupon.py
@@ -40,7 +40,7 @@ class TestDynamicDiscountCoupon(VouchersTest):
         # Initialize all page objects
         self.course_about = CourseAboutPage(self.browser, self.course_id)
 
-    @skip
+    @skip("Need to rewrite tests for sandbox")
     def test_discount_single_use_percentage_code(self):
         """
         Scenario: Dynamic Discount Single Use Percentage Code: Code cannot

--- a/regression/tests/whitelabel/test_dynamic_enrollment_coupon.py
+++ b/regression/tests/whitelabel/test_dynamic_enrollment_coupon.py
@@ -17,8 +17,7 @@ from regression.tests.helpers.coupon_consts import (
 from regression.pages.whitelabel.redeem_coupon_page import RedeemCouponPage
 from regression.tests.helpers.coupon import Coupon
 from regression.pages.whitelabel.const import (
-    PASSWORD,
-    PROF_COURSE_ID
+    PASSWORD
 )
 from regression.pages.whitelabel.course_about_page import CourseAboutPage
 from regression.tests.helpers.utils import construct_course_basket_page_url
@@ -42,9 +41,9 @@ class TestDynamicEnrollmentCoupon(VouchersTest):
         self.total_price = course_info['price']
         self.course_title = course_info['title']
         # Initialize all page objects
-        self.course_about = CourseAboutPage(self.browser, PROF_COURSE_ID)
+        self.course_about = CourseAboutPage(self.browser, self.course_id)
 
-    @skip
+    @skip("Need to rewrite tests for sandbox")
     def test_enrollment_once_per_customer_code_max_limit(self):
         """
         Scenario: Dynamic Enrollment Once Per Customer - Code Max Limit: Each
@@ -82,7 +81,7 @@ class TestDynamicEnrollmentCoupon(VouchersTest):
                     ONCE_PER_CUSTOMER_CODE_MAX_LIMIT
                 )
 
-    @skip
+    @skip("Need to rewrite tests for sandbox")
     def test_apply_enrollment_once_per_customer_redeem_url(self):
         """
         Scenario: Registered Users: Dynamic Enrollment Once Per Customer

--- a/regression/tests/whitelabel/test_misc.py
+++ b/regression/tests/whitelabel/test_misc.py
@@ -4,17 +4,14 @@ Miscellaneous tests
 from unittest import skipIf
 
 from regression.pages.whitelabel.const import (
-    EXISTING_USER_EMAIL,
     LOGO_ALT_TEXT,
     LOGO_LINK,
     NO_OF_COUNTRIES,
     NO_OF_LANGUAGES,
     ORG,
-    PASSWORD,
     SAMPLE_COUNTRIES,
     SAMPLE_LANGUAGES,
     SELECTED_COUNTRY,
-    SELECTED_LANGUAGE,
     SOCIAL_MEDIA_LINK
 )
 from regression.pages.whitelabel.profile_page import ProfilePage
@@ -36,7 +33,7 @@ class TestMisc(WhiteLabelTestsBaseClass):
         self.profile_page = ProfilePage(self.browser)
 
     @skipIf(ORG == 'MITxPRO', 'MITxPRO has no social media links')
-    def test_verify_social_media_links(self):
+    def test_social_media_links(self):
         """
         Scenario: To verify that correct social media links are present in
         footer section
@@ -44,7 +41,7 @@ class TestMisc(WhiteLabelTestsBaseClass):
         self.home_page.visit()
         self.assertEqual(SOCIAL_MEDIA_LINK, self.home_page.social_links)
 
-    def test_verify_logos(self):
+    def test_logos(self):
         """
         Scenario: To verify that correct images are being used for header and
         footer logos
@@ -59,13 +56,12 @@ class TestMisc(WhiteLabelTestsBaseClass):
         # Get the alt text for footer logo and verify it
         self.assertEqual(LOGO_ALT_TEXT, self.home_page.footer_logo_alt_text)
 
-    def test_verify_countries_data(self):
+    def test_countries_data(self):
         """
         Scenario: To verify that correct countries data is present in user
         profile
         """
-        self.login_page.visit()
-        self.login_page.provide_info(EXISTING_USER_EMAIL, PASSWORD)
+        self.register_using_api()
         self.dashboard_page.wait_for_page()
         # Open the profile page
         self.dashboard_page.go_to_profile_page()
@@ -78,21 +74,16 @@ class TestMisc(WhiteLabelTestsBaseClass):
         for country in SAMPLE_COUNTRIES:
             self.assertIn(country, countries)
 
-    def test_verify_languages_data(self):
+    def test_languages_data(self):
         """
         Scenario: To verify that correct languages data is present in user
         profile
         """
-        self.login_page.visit()
-        self.login_page.provide_info(EXISTING_USER_EMAIL, PASSWORD)
+        self.register_using_api()
         self.dashboard_page.wait_for_page()
         # Open the profile page
         self.dashboard_page.go_to_profile_page()
         self.profile_page.wait_for_page()
-        # Get selected Language and validate it
-        self.assertEqual(
-            SELECTED_LANGUAGE, self.profile_page.selected_language
-        )
         # Get languages list and validate it
         languages = self.profile_page.languages_list
         self.assertEqual(NO_OF_LANGUAGES, len(languages))

--- a/regression/tests/whitelabel/white_label_tests_base.py
+++ b/regression/tests/whitelabel/white_label_tests_base.py
@@ -1,12 +1,15 @@
 """
 Base class for white label tests
 """
+import os
+
 from bok_choy.web_app_test import WebAppTest
 
 from regression.pages.whitelabel.const import (
-    ECOMMERCE_URL_WITHOUT_AUTH,
-    URL_WITHOUT_AUTH
+    ECOM_URL,
+    LMS_URL
 )
+from regression.pages.whitelabel.basket_page import BasketPage
 from regression.pages.whitelabel.dashboard_page import DashboardPageExtended
 from regression.pages.whitelabel.home_page import HomePage
 from regression.pages.whitelabel.login_page import LoginPage
@@ -30,6 +33,7 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         self.login_page = LoginPage(self.browser)
         self.registration_page = RegisterPageExtended(self.browser)
         self.logout_page = EcommerceLogoutPage(self.browser)
+        self.basket_page = BasketPage(self.browser)
         self.ecom_cookies = None
 
     def login_user_using_ui(self, email, password):
@@ -47,6 +51,11 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         """
         register_user = WLRegisterApi(target_page=target)
         register_user.authenticate(self.browser)
+        if target:
+            if "account/finish_auth?course_id" in target:
+                self.basket_page.wait_for_page()
+        else:
+            self.dashboard_page.wait_for_page()
 
     def logout_user_from_lms(self):
         """
@@ -67,7 +76,7 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         logout using api
         """
         logout_api = LogoutApi()
-        logout_api.logout_url = '{}{}'.format(URL_WITHOUT_AUTH, 'logout')
+        logout_api.logout_url = os.path.join(LMS_URL, 'logout')
         logout_api.cookies = self.browser.get_cookies()
         logout_api.logout()
 
@@ -76,9 +85,6 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         Use ecommerce cookies to logout
         """
         logout_api = LogoutApi()
-        logout_api.logout_url = '{}{}'.format(
-            ECOMMERCE_URL_WITHOUT_AUTH,
-            'logout'
-        )
+        logout_api.logout_url = os.path.join(ECOM_URL, 'logout')
         logout_api.cookies = self.ecom_cookies
         logout_api.logout()


### PR DESCRIPTION
Hi @bill-filler ,

Here is the first draft of changes which enable tests to run on sandbox.

Currently there are some rough edges to fix.

These tests will fail for stage as the org name used in stage is different(MITxPRO) than in sandbox(mitxpro), when the name change is done for both environments these tests should pass.

There is a bug on sandbox due to which course is not shown in dashboard after enrollment, due to this bug majority of test cases would fail

The Environment Variables required to run these tests are updated in readme, you would need to fetch the OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET from django admin for main ecommerce site.

For TEST_ENV just use helio

Let me know if you run into any issues while running the tests.

One more thing, the bok-choy or selenium is not supported on newer firefox versions so you need to downgrade your firefox to 47.0.1 version or use gecko driver (you would need to put gecko driver in path)

cc @afzaledx @hasnain-naveed 
