### PR TITLE
TE-2517 Fix test_cancel_upload with existing image

### DIFF
--- a/regression/tests/studio/test_schedule_and_details_settings.py
+++ b/regression/tests/studio/test_schedule_and_details_settings.py
@@ -94,7 +94,7 @@ class ScheduleAndDetailsTest(WebAppTest):
         ).get_attribute('value')
         self.settings_page.visit()
         # Upload the image.
-        self.settings_page.upload_course_image('Image.png')
+        self.settings_page.upload_course_image('1.png')
         # Cancel the upload
         self.settings_page.cancel_upload()
         # Course card image should be the same as before.


### PR DESCRIPTION
When you tell selenium to prepare to upload a file, Firefox 59 actually cares if it exists or not; Chrome apparently doesn't until you actually upload it.  I picked an existing image to use, it won't actually be uploaded anyway.