### PR TITLE
Fix travis by pinning docker-ce version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ after_success:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     docker --version;
     sudo apt-get -y update;
-    sudo apt-get -y install -o Dpkg::Options::="--force-confnew" docker-ce;
+    sudo apt-get -y install -o Dpkg::Options::="--force-confnew" docker-ce=18.03.0~ce-0~ubuntu;
     docker --version;
     docker-compose build;
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASS";


### PR DESCRIPTION
docker ce version 18.04.0 was prompting us before logging in, which resulted in a timeout and a failed build. Someone has reported the issue here: https://github.com/docker/cli/issues/1002 . For now, let's pin the version to 18.03.0.