### PR TITLE
update bokchoy and selenium

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,9 @@
-selenium==3.11.0
+selenium==3.14.0
 path.py==7.2
 requests==2.0.1
 nose==1.3.7
 Paver==1.2.4
-bok-choy==0.8.0
+bok-choy==0.9.0
 needle==0.5.0
 pep8==1.5.7
 pylint==1.5.5


### PR DESCRIPTION
We have been seeing  frequent failures in both the e2e tests and microsites jobs for the last few weeks. The failures always seem to occur on the first (and rarely second) test in a suite, while all other tests pass. They always fail for the same reason, namely: 
``` 
File "/usr/lib/python2.7/unittest/case.py", line 320, in run
    self.setUp()
  File "/home/jenkins/workspace/edx-e2e-tests/regression/tests/common/test_html_component.py", line 70, in setUp
    super(StudioLmsAdvancedComponentTest, self).setUp()
  File "/home/jenkins/workspace/edx-e2e-tests/regression/tests/common/test_html_component.py", line 39, in setUp
    lms_login.authenticate(self.browser)
  File "/home/jenkins/workspace/edx-e2e-tests/regression/tests/helpers/api_clients.py", line 171, in authenticate
    browser.get(self.browser_get_url)
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 324, in get
    self.execute(Command.GET, {'url': url})
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 310, in execute
    response = self.command_executor.execute(driver_command, params)
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/remote_connection.py", line 466, in execute
    return self._request(command_info[0], url, body=data)
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/remote_connection.py", line 490, in _request
    resp = self._conn.getresponse()
  File "/usr/lib/python2.7/httplib.py", line 1136, in getresponse
    response.begin()
  File "/usr/lib/python2.7/httplib.py", line 453, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python2.7/httplib.py", line 417, in _read_status
    raise BadStatusLine(line)
"''\n-------------------- >> begin captured logging << --------------------\nbok_choy.browser: INFO: Using local browser: firefox [Default is firefox]\nbok_choy.browser: INFO: Using default firefox profile\n--------------------- >> end captured logging << ---------------------"
```

After looking for similar issues on the selenium project, I noticed this: https://github.com/mozilla/geckodriver/issues/1304

I can't say with absolute certainty, but it *feels* like the start of these failures coincide with a recent Firefox upgrade, which included a geckodriver upgrade. The new version of geckodriver supports HTTP keep-alives, but has a very short [default value (5s)](https://hyper.rs/hyper/0.8.0/hyper/server/struct.Server.html#method.keep_alive). Due to a [bug](https://bugs.python.org/issue3566) in Pythons httplib, Selenium WebDriver cannot detect that a servers keep-alive has expired and it has closed the connection, so it throws up it's hands and raises a BadStatusLine exception. It is possible that the first test in a test suite hit some sort of first time penalty when authenticating w/ stage and therefore exceeds the 5s mark, triggering the BadStatusLine.

While we wait for Geckodriver to be updated, a [newer version](https://github.com/SeleniumHQ/selenium/pull/6103) of the Selenium python bindings (3.14) has been released that uses urllib3, which handles keep-alives. This PR bumps both selenium and bokchoy, which contains the updated version of selenium.