### PR TITLE
Revert "skip discount tests WL-1791"

### DIFF
--- a/regression/tests/whitelabel/test_discount_coupon.py
+++ b/regression/tests/whitelabel/test_discount_coupon.py
@@ -42,7 +42,6 @@ from regression.tests.helpers.utils import (
 from regression.tests.whitelabel.voucher_tests_base import VouchersTest
 
 
-@skip("Skipped due to wl_1791")
 class TestDiscountCoupon(VouchersTest):
     """
     Tests for Single Course Discount Coupons


### PR DESCRIPTION
I merged https://github.com/edx/edx-e2e-tests/pull/308 in on Friday and think it will fix the underlying problem causing the initial BadStatusLine errors. Let's let a few pipeline jobs prove this, then revert this commit.