### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/pavelib/paver_tests/utils.py
+++ b/pavelib/paver_tests/utils.py
@@ -4,6 +4,11 @@ import os
 from paver import tasks
 from unittest import TestCase
 
+try:
+    unicode        # Python 2
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+
 
 class PaverTestCase(TestCase):
     """

--- a/pavelib/paver_tests/utils.py
+++ b/pavelib/paver_tests/utils.py
@@ -1,13 +1,9 @@
 """Unit tests for the Paver server tasks."""
 
 import os
+from six import text_type
 from paver import tasks
 from unittest import TestCase
-
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 
 class PaverTestCase(TestCase):
@@ -58,4 +54,4 @@ class MockEnvironment(tasks.Environment):
         else:
             output = message
         if not output.startswith("--->"):
-            self.messages.append(unicode(output))
+            self.messages.append(text_type(output))

--- a/pavement.py
+++ b/pavement.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 sys.path.insert(0, os.path.dirname(__file__))
@@ -51,7 +52,7 @@ def install_pages():
         'capa'
     ))
 
-    print 'Installing the Page Objects'
+    print('Installing the Page Objects')
     sh("pip install -r {req} --src={lib}".format(
         req=requirement_path, lib=lib_path))
     # Install pages

--- a/regression/pages/lms/utils.py
+++ b/regression/pages/lms/utils.py
@@ -3,10 +3,7 @@ Utility functions for lms page objects.
 """
 from opaque_keys.edx.locator import CourseLocator
 
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+from six import text_type
 
 
 def get_course_key(course_info, module_store='split'):
@@ -21,4 +18,4 @@ def get_course_key(course_info, module_store='split'):
         course_info['run'],
         deprecated=(module_store == 'draft')
     )
-    return unicode(course_key)
+    return text_type(course_key)

--- a/regression/pages/lms/utils.py
+++ b/regression/pages/lms/utils.py
@@ -3,6 +3,11 @@ Utility functions for lms page objects.
 """
 from opaque_keys.edx.locator import CourseLocator
 
+try:
+    unicode        # Python 2
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+
 
 def get_course_key(course_info, module_store='split'):
     """

--- a/regression/pages/studio/settings_studio.py
+++ b/regression/pages/studio/settings_studio.py
@@ -22,7 +22,7 @@ class SettingsPageExtended(SettingsPage):
         Construct a URL to the page within the course.
         """
         course_id = get_course_key(self.course_info)
-        return LOGIN_BASE_URL + "/" + self.url_path + "/" + text_type(course_id)
+        return "/".join((LOGIN_BASE_URL, self.url_path, text_type(course_id)))
 
     def is_browser_on_page(self):
         return self.q(css='body.view-settings #course-organization').visible \

--- a/regression/pages/studio/settings_studio.py
+++ b/regression/pages/studio/settings_studio.py
@@ -8,6 +8,11 @@ from regression.pages import UPLOAD_FILE_DIR
 from regression.pages.studio.utils import get_course_key
 from regression.pages.studio import LOGIN_BASE_URL
 
+try:
+    unicode        # Python 2
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+
 
 class SettingsPageExtended(SettingsPage):
     """

--- a/regression/pages/studio/settings_studio.py
+++ b/regression/pages/studio/settings_studio.py
@@ -4,11 +4,11 @@ Course Schedule and Details Settings page.
 from edxapp_acceptance.pages.studio.settings import SettingsPage
 from edxapp_acceptance.pages.common.utils import click_css
 
+from six import text_type
+
 from regression.pages import UPLOAD_FILE_DIR
 from regression.pages.studio.utils import get_course_key
 from regression.pages.studio import LOGIN_BASE_URL
-
-from six import text_type
 
 
 class SettingsPageExtended(SettingsPage):

--- a/regression/pages/studio/settings_studio.py
+++ b/regression/pages/studio/settings_studio.py
@@ -8,10 +8,7 @@ from regression.pages import UPLOAD_FILE_DIR
 from regression.pages.studio.utils import get_course_key
 from regression.pages.studio import LOGIN_BASE_URL
 
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+from six import text_type
 
 
 class SettingsPageExtended(SettingsPage):
@@ -25,7 +22,7 @@ class SettingsPageExtended(SettingsPage):
         Construct a URL to the page within the course.
         """
         course_id = get_course_key(self.course_info)
-        return LOGIN_BASE_URL + "/" + self.url_path + "/" + unicode(course_id)
+        return LOGIN_BASE_URL + "/" + self.url_path + "/" + text_type(course_id)
 
     def is_browser_on_page(self):
         return self.q(css='body.view-settings #course-organization').visible \

--- a/regression/tests/helpers/utils.py
+++ b/regression/tests/helpers/utils.py
@@ -1,6 +1,7 @@
 """
 Test helper functions.
 """
+from __future__ import print_function
 import os
 import uuid
 
@@ -85,7 +86,7 @@ def visit_all(pages):
         pages:
     """
     for page in pages:
-        print "Visiting: {}".format(page)
+        print("Visiting: {}".format(page))
         page.visit()
 
 

--- a/regression/tests/helpers/utils.py
+++ b/regression/tests/helpers/utils.py
@@ -18,6 +18,11 @@ COURSE_NUMBER = 'COURSE_NUMBER'
 COURSE_RUN = 'COURSE_RUN'
 COURSE_DISPLAY_NAME = 'COURSE_DISPLAY_NAME'
 
+try:
+    unicode        # Python 2
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+
 
 def get_random_credentials():
     """

--- a/regression/tests/helpers/utils.py
+++ b/regression/tests/helpers/utils.py
@@ -5,6 +5,8 @@ from __future__ import print_function
 import os
 import uuid
 
+from six import text_type
+
 from regression.pages.studio import LOGIN_BASE_URL
 from regression.pages.studio.utils import get_course_key
 from regression.pages.whitelabel.activate_account import ActivateAccount
@@ -17,11 +19,6 @@ COURSE_ORG = 'COURSE_ORG'
 COURSE_NUMBER = 'COURSE_NUMBER'
 COURSE_RUN = 'COURSE_RUN'
 COURSE_DISPLAY_NAME = 'COURSE_DISPLAY_NAME'
-
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 
 def get_random_credentials():
@@ -103,7 +100,7 @@ def get_url(url_path, course_info):
         course_info:
     """
     course_key = get_course_key(course_info)
-    return "/".join([LOGIN_BASE_URL, url_path, unicode(course_key)])
+    return "/".join([LOGIN_BASE_URL, url_path, text_type(course_key)])
 
 
 def get_data_locator(page):

--- a/regression/tests/whitelabel/course_enrollment_test.py
+++ b/regression/tests/whitelabel/course_enrollment_test.py
@@ -26,6 +26,11 @@ from regression.tests.whitelabel.white_label_tests_base import (
     WhiteLabelTestsBaseClass
 )
 
+try:
+    unicode        # Python 2
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+
 
 class CourseNotFoundException(Exception):
     """

--- a/regression/tests/whitelabel/course_enrollment_test.py
+++ b/regression/tests/whitelabel/course_enrollment_test.py
@@ -5,6 +5,8 @@ import datetime
 
 from bok_choy.promise import EmptyPromise
 
+from six import text_type
+
 from regression.pages.whitelabel.basket_page import (
     CyberSourcePage,
     MultiSeatBasketPage,
@@ -25,8 +27,6 @@ from regression.tests.helpers.api_clients import (
 from regression.tests.whitelabel.white_label_tests_base import (
     WhiteLabelTestsBaseClass
 )
-
-from six import text_type
 
 
 class CourseNotFoundException(Exception):

--- a/regression/tests/whitelabel/course_enrollment_test.py
+++ b/regression/tests/whitelabel/course_enrollment_test.py
@@ -26,10 +26,7 @@ from regression.tests.whitelabel.white_label_tests_base import (
     WhiteLabelTestsBaseClass
 )
 
-try:
-    unicode        # Python 2
-except NameError:  # Python 3
-    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+from six import text_type
 
 
 class CourseNotFoundException(Exception):
@@ -228,7 +225,7 @@ class CourseEnrollmentTest(WhiteLabelTestsBaseClass):
         self.assertEqual(
             # Slight chance that this will fail if the test execution crosses
             # the boundary of midnight
-            unicode(datetime.datetime.utcnow().date()),
+            text_type(datetime.datetime.utcnow().date()),
             self.receipt_page.order_date
         )
         self.assertEqual(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 selenium==3.14.0
+six==1.12.0
 path.py==7.2
 requests==2.0.1
 nose==1.3.7


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.