### PR TITLE
Update the rest-api client and requests.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 selenium==3.14.0
 six==1.12.0
 path.py==7.2
-requests==2.0.1
+requests==2.21.0
 nose==1.3.7
 Paver==1.2.4
 bok-choy==0.9.0
@@ -10,7 +10,7 @@ pycodestyle==2.5.0
 pylint==1.5.5
 edx-lint==0.5.1
 edx-opaque-keys==0.2.1
-edx-rest-api-client==1.6.0
+edx-rest-api-client==1.9.2
 ddt==1.1.1
 mock==1.0.1
 temp-mail==0.2


### PR DESCRIPTION
When running e2e tests we get lots of errors of the form:
```
15:55:36 Traceback (most recent call last):
15:55:36   File "/home/jenkins/workspace/microsites-staging-tests/****-e2e-tests/regression/tests/whitelabel/test_enrollment_coupon.py", line 48, in setUp
15:55:36     super(TestEnrollmentCoupon, self).setUp()
15:55:36   File "/home/jenkins/workspace/microsites-staging-tests/****-e2e-tests/regression/tests/whitelabel/voucher_tests_base.py", line 25, in setUp
15:55:36     super(VouchersTest, self).setUp()
15:55:36   File "/home/jenkins/workspace/microsites-staging-tests/****-e2e-tests/regression/tests/whitelabel/course_enrollment_test.py", line 47, in setUp
15:55:36     self.enrollment_api_client = EnrollmentApiClient()
15:55:36   File "/home/jenkins/workspace/microsites-staging-tests/****-e2e-tests/regression/tests/helpers/api_clients.py", line 374, in __init__
15:55:36     access_token, __ = self.get_access_token()
15:55:36   File "/home/jenkins/workspace/microsites-staging-tests/****-e2e-tests/regression/tests/helpers/api_clients.py", line 392, in get_access_token
15:55:36     token_type='jwt'
15:55:36   File "/home/jenkins/workspace/microsites-staging-tests/****-e2e-tests/venv/local/lib/python2.7/site-packages/****_rest_api_client/client.py", line 42, in get_oauth_access_token
15:55:36     raise requests.RequestException(response=response)
15:55:36 TypeError: RequestException does not take keyword arguments
```

It looks like at some point we started using the new capabilities of the
RequestException class without actually upgrading requests.