### PR TITLE
Optimized logic around getting cookie domain

### DIFF
--- a/regression/tests/lms/test_graded_problem.py
+++ b/regression/tests/lms/test_graded_problem.py
@@ -59,4 +59,5 @@ class GradedProblemTest(WebAppTest):
         Verifies submission of a graded problem
         """
         self.course_page.click_resume_button()
+        self.lms_courseware.wait_for_page()
         self.lms_courseware.submit_graded_problem()


### PR DESCRIPTION
Optimized logic around getting cookie domain which would enable us to run e2e tests on edx sandboxes.
Fixed flakiness in `test_graded_problem`.