### PR TITLE
Logout of ecommerce via the browser.

### DIFF
--- a/regression/pages/whitelabel/logout_page.py
+++ b/regression/pages/whitelabel/logout_page.py
@@ -3,34 +3,29 @@ Logout Page
 """
 from __future__ import absolute_import
 
+import os
 from bok_choy.page_object import PageObject
+
+from regression.pages.whitelabel import ECOM_URL_WITH_AUTH
+from regression.pages.whitelabel.home_page import HomePage
 
 
 class EcommerceLogoutPage(PageObject):
     """
     E-Commerce Logout
+
+    Use visit() to actually perform the logout.
     """
 
-    url = None
+    url = os.path.join(ECOM_URL_WITH_AUTH, 'logout/')
 
     def is_browser_on_page(self):
         """
         Is browser on the page?
         Returns:
-            True if user drop down is visible on the page:
+            True if the sign out message is on the page.
         """
-        return self.q(css='.user-menu').visible
+        home_page = HomePage(self.browser)
 
-    def logout_from_ecommerce(self):
-        """
-        Log out from application
-        """
-        self.q(
-            css='.user-menu>.btn.btn-default.dropdown-toggle.'
-            'hidden-xs.nav-button'
-        ).click()
-        self.wait_for_element_visibility(
-            '.dropdown-menu',
-            'wait for user dropdown to expand'
-        )
-        self.q(css='.nav-link[href="/logout/"]').click()
+        return ("you have signed out" in self.browser.page_source.lower()) or \
+            home_page.is_browser_on_page()

--- a/regression/tests/whitelabel/course_enrollment_test.py
+++ b/regression/tests/whitelabel/course_enrollment_test.py
@@ -85,7 +85,6 @@ class CourseEnrollmentTest(WhiteLabelTestsBaseClass):
         """
         Verify that course name is displayed correctly on basket page.
         """
-        self.ecom_cookies = self.browser.get_cookies()
         self.assertIn(self.course_title, self.basket_page.course_name)
 
     def verify_price_on_basket(self):

--- a/regression/tests/whitelabel/course_enrollment_test.py
+++ b/regression/tests/whitelabel/course_enrollment_test.py
@@ -98,13 +98,13 @@ class CourseEnrollmentTest(WhiteLabelTestsBaseClass):
             [self.course_price, self.total_price]
         )
 
-    def assert_enrollment_and_logout(self):
+    def assert_enrollment_and_logout_of_ecommerce(self):
         """
         Verify that course is added to user dashboard and user can access
         the course. After that, logout from application.
         """
         self.assert_course_added_to_dashboard()
-        self.logout_from_ecommerce_using_api()
+        self.logout_user_from_ecommerce()
 
     def assert_course_added_to_dashboard(self):
         """

--- a/regression/tests/whitelabel/test_discount_coupon.py
+++ b/regression/tests/whitelabel/test_discount_coupon.py
@@ -74,7 +74,7 @@ class TestDiscountCoupon(VouchersTest):
             construct_course_basket_page_url(self.course_id)
         )
         self.enroll_using_discount_code(coupon_code)
-        self.assert_enrollment_and_logout()
+        self.assert_enrollment_and_logout_of_ecommerce()
         self.register_using_api(
             construct_course_basket_page_url(self.course_id)
         )
@@ -146,7 +146,6 @@ class TestDiscountCoupon(VouchersTest):
             EXPIRED_CODE_ERROR.format(coupon_code)
         )
 
-    @skip("skipped while we investigate what's going on with this test")
     def test_discount_single_use_fixed_redeem_url(self):
         """
         Scenario: Existing Users - Discount Single Use Fixed Redeem URL: Each
@@ -176,7 +175,7 @@ class TestDiscountCoupon(VouchersTest):
             self.ecom_cookies = self.browser.get_cookies()
             self.make_payment_after_discount()
             self.dashboard_page.wait_for_page()
-            self.assert_enrollment_and_logout()
+            self.assert_enrollment_and_logout_of_ecommerce()
 
     @skipIf(TEST_ENV == "stage", "skip tests on stage")
     def test_discount_once_per_customer_percentage_redeem_url(self):

--- a/regression/tests/whitelabel/test_discount_coupon.py
+++ b/regression/tests/whitelabel/test_discount_coupon.py
@@ -172,7 +172,6 @@ class TestDiscountCoupon(VouchersTest):
             self.register_using_api()
             self.redeem_single_course_discount_coupon(coupon_code)
             self.basket_page.wait_for_page()
-            self.ecom_cookies = self.browser.get_cookies()
             self.make_payment_after_discount()
             self.dashboard_page.wait_for_page()
             self.assert_enrollment_and_logout_of_ecommerce()

--- a/regression/tests/whitelabel/test_dynamic_discount_coupon.py
+++ b/regression/tests/whitelabel/test_dynamic_discount_coupon.py
@@ -61,7 +61,7 @@ class TestDynamicDiscountCoupon(VouchersTest):
             construct_course_basket_page_url(self.course_id)
         )
         self.enroll_using_discount_code(coupon_code)
-        self.assert_enrollment_and_logout()
+        self.assert_enrollment_and_logout_of_ecommerce()
         # Register to application using api
         self.register_using_api(
             construct_course_basket_page_url(self.course_id)

--- a/regression/tests/whitelabel/test_dynamic_enrollment_coupon.py
+++ b/regression/tests/whitelabel/test_dynamic_enrollment_coupon.py
@@ -67,7 +67,7 @@ class TestDynamicEnrollmentCoupon(VouchersTest):
                     construct_course_basket_page_url(self.course_id)
                 )
                 self.enroll_using_enrollment_code(coupon_code)
-                self.assert_enrollment_and_logout()
+                self.assert_enrollment_and_logout_of_ecommerce()
             else:
                 # Register to application using api
                 self.register_using_api(
@@ -114,7 +114,7 @@ class TestDynamicEnrollmentCoupon(VouchersTest):
                 self.verify_receipt_info_for_discounted_course()
                 self.receipt_page.click_in_nav_to_go_to_dashboard()
                 self.dashboard_page.wait_for_page()
-                self.assert_enrollment_and_logout()
+                self.assert_enrollment_and_logout_of_ecommerce()
             else:
                 self.register_using_api()
                 redeem_coupon = RedeemCouponPage(

--- a/regression/tests/whitelabel/test_enrollment_coupon.py
+++ b/regression/tests/whitelabel/test_enrollment_coupon.py
@@ -161,7 +161,6 @@ class TestEnrollmentCoupon(VouchersTest):
             coupon_code,
             self.receipt_page
         )
-        self.ecom_cookies = self.browser.get_cookies()
         self.receipt_page.wait_for_page()
         self.verify_receipt_info_for_discounted_course()
         self.receipt_page.click_in_nav_to_go_to_dashboard()

--- a/regression/tests/whitelabel/test_enrollment_coupon.py
+++ b/regression/tests/whitelabel/test_enrollment_coupon.py
@@ -76,7 +76,7 @@ class TestEnrollmentCoupon(VouchersTest):
                 construct_course_basket_page_url(self.course_id)
             )
             self.enroll_using_enrollment_code(coupon_code)
-            self.assert_enrollment_and_logout()
+            self.assert_enrollment_and_logout_of_ecommerce()
 
     def test_enrollment_once_per_customer_code_max_limit(self):
         """
@@ -106,7 +106,7 @@ class TestEnrollmentCoupon(VouchersTest):
             )
             if i < maximum_uses:
                 self.enroll_using_enrollment_code(coupon_code)
-                self.assert_enrollment_and_logout()
+                self.assert_enrollment_and_logout_of_ecommerce()
             else:
                 self.assertEqual(
                     self.error_message_on_invalid_coupon_code(coupon_code),
@@ -166,7 +166,7 @@ class TestEnrollmentCoupon(VouchersTest):
         self.verify_receipt_info_for_discounted_course()
         self.receipt_page.click_in_nav_to_go_to_dashboard()
         self.dashboard_page.wait_for_page()
-        self.assert_enrollment_and_logout()
+        self.assert_enrollment_and_logout_of_ecommerce()
         self.register_using_api()
         self.redeem_single_course_enrollment_coupon(
             coupon_code,

--- a/regression/tests/whitelabel/voucher_tests_base.py
+++ b/regression/tests/whitelabel/voucher_tests_base.py
@@ -34,7 +34,6 @@ class VouchersTest(CourseEnrollmentTest):
         Arguments:
             coupon_code(unicode string): The coupon code to use for enrollment.
         """
-        self.ecom_cookies = self.browser.get_cookies()
         self.single_seat_basket.apply_coupon_code(coupon_code)
         self.verify_coupon_is_applied_on_basket()
         # Fill out all the billing and payment details and submit the form
@@ -53,7 +52,6 @@ class VouchersTest(CourseEnrollmentTest):
         Arguments:
             coupon_code(unicode string): The coupon code to use for enrollment.
         """
-        self.ecom_cookies = self.browser.get_cookies()
         self.single_seat_basket.apply_coupon_code(coupon_code)
         self.verify_after_coupon_is_applied_on_basket()
         self.single_seat_basket.go_to_receipt_page()
@@ -75,7 +73,6 @@ class VouchersTest(CourseEnrollmentTest):
         Returns:
             str: The error message after applying the coupon.
         """
-        self.ecom_cookies = self.browser.get_cookies()
         self.single_seat_basket.apply_coupon_code(coupon_code)
         return self.single_seat_basket.get_error_message_for_invalid_coupon()
 

--- a/regression/tests/whitelabel/voucher_tests_base.py
+++ b/regression/tests/whitelabel/voucher_tests_base.py
@@ -107,44 +107,44 @@ class VouchersTest(CourseEnrollmentTest):
             self.receipt_page.order_date
         )
 
-    def redeem_single_course_discount_coupon(self, coupon_url):
+    def redeem_single_course_discount_coupon(self, coupon_code):
         """
         Redeem single course discount coupon.
 
         Arguments:
-            coupon_url: Url of the coupon.
+            coupon_code: coupon_code to use as part of the url.
         """
-        redeem_coupon_page = RedeemCouponPage(self.browser, coupon_url)
+        redeem_coupon_page = RedeemCouponPage(self.browser, coupon_code)
         redeem_coupon_page.visit()
         redeem_coupon_page.wait_for_course_tile()
         self.verify_course_info_on_coupon_redeem_page(redeem_coupon_page)
         redeem_coupon_page.click_checkout_button(self.course_id)
 
-    def redeem_single_course_enrollment_coupon(self, coupon_url, target_page):
+    def redeem_single_course_enrollment_coupon(self, coupon_code, target_page):
         """
         Redeem single course enrollment coupon
         Args
-            coupon_url: Url of the coupon.
+            coupon_code: coupon_code to use as part of the url.
             target_page: Destination page.
         """
-        redeem_coupon_page = RedeemCouponPage(self.browser, coupon_url).visit()
+        redeem_coupon_page = RedeemCouponPage(self.browser, coupon_code).visit()
         redeem_coupon_page.wait_for_course_tile()
         self.verify_course_info_on_coupon_redeem_page(redeem_coupon_page)
         redeem_coupon_page.redeem_enrollment(target_page)
 
     def redeem_multi_course_enrollment_coupon(
             self,
-            coupon_url,
+            coupon_code,
             target_page,
             course_title):
         """
         Redeem single course enrollment coupon
         Args
-            coupon_url: Url of the coupon.
+            coupon_code: coupon_code to use as part of the url.
             target_page: Destination page.
             course_title: Title of the course.
         """
-        redeem_coupon_page = RedeemCouponPage(self.browser, coupon_url).visit()
+        redeem_coupon_page = RedeemCouponPage(self.browser, coupon_code).visit()
         redeem_coupon_page.wait_for_course_tile()
         redeem_coupon_page.set_course_tile_index(course_title)
         self.verify_course_info_on_coupon_redeem_page(redeem_coupon_page)

--- a/regression/tests/whitelabel/white_label_tests_base.py
+++ b/regression/tests/whitelabel/white_label_tests_base.py
@@ -33,7 +33,6 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         self.registration_page = RegisterPageExtended(self.browser)
         self.logout_page = EcommerceLogoutPage(self.browser)
         self.basket_page = BasketPage(self.browser)
-        self.ecom_cookies = None
 
     def login_user_using_ui(self, email, password):
         """

--- a/regression/tests/whitelabel/white_label_tests_base.py
+++ b/regression/tests/whitelabel/white_label_tests_base.py
@@ -8,7 +8,7 @@ import os
 from bok_choy.web_app_test import WebAppTest
 
 from regression.pages.whitelabel.basket_page import BasketPage
-from regression.pages.whitelabel.const import ECOM_URL, LMS_URL
+from regression.pages.whitelabel.const import LMS_URL
 from regression.pages.whitelabel.dashboard_page import DashboardPageExtended
 from regression.pages.whitelabel.home_page import HomePage
 from regression.pages.whitelabel.login_page import LoginPage
@@ -67,7 +67,7 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         """
         Logout user from ecommerce site
         """
-        self.logout_page.logout_from_ecommerce()
+        self.logout_page.visit()
 
     def logout_from_wl_using_api(self):
         """
@@ -77,13 +77,4 @@ class WhiteLabelTestsBaseClass(WebAppTest):
         logout_api = LogoutApi()
         logout_api.logout_url = os.path.join(LMS_URL, 'logout')
         logout_api.cookies = self.browser.get_cookies()
-        logout_api.logout()
-
-    def logout_from_ecommerce_using_api(self):
-        """
-        Use ecommerce cookies to logout
-        """
-        logout_api = LogoutApi()
-        logout_api.logout_url = os.path.join(ECOM_URL, 'logout')
-        logout_api.cookies = self.ecom_cookies
         logout_api.logout()


### PR DESCRIPTION
Logging out of ecom via the API the way it was being done here with the
ecommerce cookies was flaky for a long time but recently just started
always failing.  When logging out via the browser, everything seems to
be working as expected so we'll do that instead.