### PR TITLE
added confirm_email to required fields

### DIFF
--- a/regression/tests/helpers/utils.py
+++ b/regression/tests/helpers/utils.py
@@ -165,6 +165,7 @@ def get_white_label_registration_fields(
     get_user_password = get_random_password()
     return {
         'email': email or get_user_email,
+        'confirm_email': email or get_user_email,
         'username': username or get_user_name,
         'password': password or get_user_password,
         'name': name,


### PR DESCRIPTION
[PROD-1476](https://openedx.atlassian.net/browse/PROD-1476)

After making `confirm_email` field required on the registration form, some of the tests were filing so I have added `confim_email` in `get_white_label_registration_fields` to fix failing tests.