### PR TITLE
Upgrade Django to 2.2.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 ddt==1.4.1                # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils
-django==2.2.14            # via edx-django-utils
+django==2.2.17            # via edx-django-utils
 edx-django-utils==3.2.3   # via edx-rest-api-client
 edx-lint==1.5.0           # via -r requirements/base.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -15,7 +15,7 @@ coverage==5.2             # via coveralls
 coveralls==2.1.1          # via -r requirements/travis.in
 ddt==1.4.1                # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils
-django==2.2.14            # via -r requirements/base.txt, edx-django-utils
+django==2.2.17            # via -r requirements/base.txt, edx-django-utils
 docopt==0.6.2             # via coveralls
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-rest-api-client
 edx-lint==1.5.0           # via -r requirements/base.txt


### PR DESCRIPTION
This is to make sure that we use the same Django version for all applications.

This PR should be merged in time for the Koa release (cc @nedbat); it is ready for review.