### PR TITLE
Adding generate grade report task

### DIFF
--- a/edxapp_acceptance/pages/lms/instructor_dashboard.py
+++ b/edxapp_acceptance/pages/lms/instructor_dashboard.py
@@ -1170,6 +1170,13 @@ class DataDownloadPage(PageObject):
         self.wait_for_element_visibility('#data-grade-config-text', 'Grading Configurations are visible')
         return self.q(css='#data-grade-config-text').text[0]
 
+    @property
+    def get_number_of_pending_tasks(self):
+        """
+        Returns number of pending tasks
+        """
+        return len(self.q(css=".running-tasks-table .slick-row"))
+
 
 class StudentAdminPage(PageObject):
     """

--- a/regression/tests/lms/test_instructor_dashboard.py
+++ b/regression/tests/lms/test_instructor_dashboard.py
@@ -38,3 +38,69 @@ class AnalyticsTest(WebAppTest):
         self.dashboard_page.select_course(get_course_display_name())
         self.course_page.wait_for_page()
         self.instructor_dashboard.visit()
+
+
+class DataDownloadTest(WebAppTest):
+    """
+    Regression tests on Analytics on Instructor Dashboard
+    """
+
+    def setUp(self):
+        super(DataDownloadTest, self).setUp()
+
+        login_api = LmsLoginApi()
+        login_api.authenticate(self.browser)
+
+        course_info = get_course_info()
+        self.dashboard_page = DashboardPageExtended(self.browser)
+        self.instructor_dashboard = InstructorDashboardPageExtended(
+            self.browser,
+            get_course_key(course_info)
+        )
+        self.course_page = CourseHomePageExtended(
+            self.browser,
+            get_course_key(course_info)
+        )
+        self.dashboard_page.visit()
+        self.dashboard_page.select_course(get_course_display_name())
+        self.course_page.wait_for_page()
+        self.instructor_dashboard.visit()
+        self.data_download_section = self.instructor_dashboard.select_data_download()
+
+    def test_generate_grade_report(self):
+        """
+        Tests the Generate Grade Report task
+        """
+        initial_reports = self.data_download_section.report_download_links.text
+        initial_pending_tasks = self.data_download_section.get_number_of_pending_tasks
+        self.data_download_section.generate_grade_report_button.click()
+        self.data_download_section.wait_for_available_report()
+        final_reports = self.data_download_section.report_download_links.text
+        final_pending_tasks = self.data_download_section.get_number_of_pending_tasks
+        self.assertGreater(len(final_reports), len(initial_reports))
+        self.assertEqual(final_pending_tasks, initial_pending_tasks)
+        # checking confirm message in case of success
+        confirm_message = self.data_download_section.q(css="#report-request-response.msg-confirm").text[0]
+        self.assertTrue(confirm_message)
+        # checking error message in case of failure
+        error_message = self.data_download_section.q(css="#report-request-response-error.msg-error").text[0]
+        self.assertFalse(error_message)
+
+    def test_generate_problem_grade_report(self):
+        """
+        Tests the Generate Problem Grade Report task
+        """
+        initial_reports = self.data_download_section.report_download_links.text
+        initial_pending_tasks = self.data_download_section.get_number_of_pending_tasks
+        self.data_download_section.generate_problem_report_button.click()
+        self.data_download_section.wait_for_available_report()
+        final_reports = self.data_download_section.report_download_links.text
+        final_pending_tasks = self.data_download_section.get_number_of_pending_tasks
+        self.assertGreater(len(final_reports), len(initial_reports))
+        self.assertEqual(final_pending_tasks, initial_pending_tasks)
+        # checking confirm message in case of success
+        confirm_message = self.data_download_section.q(css="#report-request-response.msg-confirm").text[0]
+        self.assertTrue(confirm_message)
+        # checking error message in case of failure
+        error_message = self.data_download_section.q(css="#report-request-response-error.msg-error").text[0]
+        self.assertFalse(error_message)


### PR DESCRIPTION
**Issue:** [BOM-2085](https://openedx.atlassian.net/browse/BOM-2085)

### Description
- Added `generate_grade_report` and `generate_problem_grade_report` tasks in `e2e regression` tests.

### Testing
- Tests capture the task failure successfully. Tested by stopping the `lms_worker` in the sandbox `celerye2e.sandbox.edx.org`. 