### PR TITLE
Update DockerFile to publish using python38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # docker build . -t edxops/e2e:latest
 
-FROM edxops/python:3.5
+FROM edxops/python:3.8
 MAINTAINER edxops
 
 # Install system libraries needed for lxml


### PR DESCRIPTION
[Docker Push](https://github.com/edx/edx-e2e-tests/actions/runs/479990677) build failed after upgrading to `python38`. Upgrading the `DockerFile` to use `python38` when pushing new image.