### PR TITLE
Use python38 image in DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # docker build . -t edxops/e2e:latest
 
-FROM edxops/python:3.8
+FROM python:3.8-slim
 MAINTAINER edxops
 
 # Install system libraries needed for lxml


### PR DESCRIPTION
Update the `Dockerfile` to use the official python image for `python3.8`.