### PR TITLE
test: Unit was not loading be default. Manualy load the sub-section a…

### DIFF
--- a/regression/pages/studio/course_outline_page.py
+++ b/regression/pages/studio/course_outline_page.py
@@ -124,3 +124,17 @@ class CourseOutlinePageExtended(CourseOutlinePage):
         Returns section names of all sections.
         """
         return self.q(css='.section-title').text
+
+    def click_sub_section(self):
+        """
+        Click on the sub-section.
+        """
+        self.q(css='.subsection-title').click()
+        self.wait_for_ajax()
+
+    def click_unit_button(self):
+        """
+        Click on the unit.
+        """
+        self.q(css='h3.unit-header-details a.unit-title').click()
+        self.wait_for_ajax()

--- a/regression/tests/common/test_html_component.py
+++ b/regression/tests/common/test_html_component.py
@@ -1,7 +1,6 @@
 """
 End to end tests for HTML Components
 """
-from unittest import skip
 from uuid import uuid4
 
 from bok_choy.web_app_test import WebAppTest
@@ -54,7 +53,6 @@ class StudioViewTest(StudioLmsComponentBaseTest):
     HTML Components tests related to 'studio view' of component.
     """
 
-    @skip("BOM-2460: Test is failing on Ubuntu 20.04.")
     def test_unit_studio_view(self):
         """
         Scenario: To test studio view of component from LMS
@@ -79,6 +77,11 @@ class StudioViewTest(StudioLmsComponentBaseTest):
         self.lms_courseware.go_to_section(section_name, subsection_name)
         # View unit in the studio
         self.lms_courseware.view_unit_in_studio()
+        # View the course in studio.
+        self.studio_course_outline.visit()
+        self.studio_course_outline.click_sub_section()
+        self.studio_course_outline.click_unit_button()
+
         self.unit_container_page.wait_for_page()
         # Correct unit component should open.
         self.assertEqual(


### PR DESCRIPTION
This test is failing on ubuntu20 jenkin worker

Test Case steps:

- Login form LMS.
- Click `View in Studio` button.
- In Studio Add Section, sub-section, unit ( word cloud ), publish it.
- Click on `View Live Version` (Unit appears in lms successfully). 
- Now Click `View in Studio` button. ( In test case unit fails to load. Following screenshot shows sub-section is not collapsed by default)
- Previous failed build [results](https://build.testeng.edx.org/view/e2e-tests/job/edx-e2e-tests/6142/).

<img width="741" alt="Screen Shot 2021-03-25 at 6 11 39 PM" src="https://user-images.githubusercontent.com/445320/112478220-97b81800-8d95-11eb-9544-d30334e5ba58.png">

But doing this manually on stage unit loads successfully. 

Proposed Fix.
I trigger the click on sub-section and unit.

Note: Issue is appearing on stage only. Locally it is working fine.
https://openedx.atlassian.net/browse/BOM-2460