### PR TITLE
chore: Remove SETUPTOOLS_USE_DISTUTILS="stdlib"

### DIFF
--- a/jenkins/end_to_end_tests.sh
+++ b/jenkins/end_to_end_tests.sh
@@ -20,5 +20,4 @@ pip install -r requirements/base.txt > log/pip_install_base.log
 
 # Set the display to the virtual frame buffer (Xvfb)
 export DISPLAY=:1
-export SETUPTOOLS_USE_DISTUTILS="stdlib" # https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0
 paver e2e_test


### PR DESCRIPTION
This was added as a temporary measure to work around a setuptools 50.0.0 issue.  We may need to add it back for 60.0.0, but I'd like to see if it can be removed currently.

Note: I am not confident in the impacts of this change.