### PR TITLE
fix: drop another reference to legacy lms views

### DIFF
--- a/regression/tests/common/test_html_component.py
+++ b/regression/tests/common/test_html_component.py
@@ -73,10 +73,6 @@ class StudioViewTest(StudioLmsComponentBaseTest):
         self.unit_container_page.add_word_cloud_component(True)
         # Get unique data locator id of the unit added).
         data_locator = get_data_locator(self.unit_container_page)
-        self.lms_courseware.visit()
-        self.lms_courseware.go_to_section(section_name, subsection_name)
-        # View unit in the studio
-        self.lms_courseware.view_unit_in_studio()
         # View the course in studio.
         self.studio_course_outline.visit()
         self.studio_course_outline.click_sub_section()


### PR DESCRIPTION
These are being removed. And in this case, it wasn't super relevant to the point of the test.