### PR TITLE
chore: python requirements upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via django
 astroid==2.11.5
     # via
@@ -14,7 +14,7 @@ attrs==21.4.0
     # via pytest
 bok-choy==1.1.1
     # via -r requirements/base.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 cffi==1.15.0
     # via pynacl
@@ -30,9 +30,9 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/base.in
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
 django==3.2.13
     # via
@@ -43,7 +43,7 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==2.4.1
     # via edx-django-utils
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via edx-rest-api-client
 edx-lint==5.2.2
     # via -r requirements/base.in
@@ -85,13 +85,13 @@ paver==1.3.4
     # via -r requirements/base.in
 pbr==5.9.0
     # via stevedore
-pillow==9.1.0
+pillow==9.1.1
     # via needle
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via pytest
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 py==1.11.0
     # via pytest
@@ -101,7 +101,7 @@ pycparser==2.21
     # via cffi
 pyjwt==2.4.0
     # via edx-rest-api-client
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/base.in
     #   edx-lint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -19,7 +19,7 @@ attrs==21.4.0
     #   pytest
 bok-choy==1.1.1
     # via -r requirements/base.txt
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -46,13 +46,13 @@ code-annotations==1.3.0
     # via
     #   -r requirements/base.txt
     #   edx-lint
-coverage==6.3.3
+coverage==6.4
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/base.txt
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -72,7 +72,7 @@ django-waffle==2.4.1
     #   edx-django-utils
 docopt==0.6.2
     # via coveralls
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
@@ -142,7 +142,7 @@ pbr==5.9.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-pillow==9.1.0
+pillow==9.1.1
     # via
     #   -r requirements/base.txt
     #   needle
@@ -154,7 +154,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/base.txt
     #   pytest
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -172,7 +172,7 @@ pyjwt==2.4.0
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/base.txt
     #   edx-lint

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip_tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
### Description
- Ran `make upgrade` locally to resolve the conflict between pip and pip-tools version when running the upgrade job.