### PR TITLE
build: Remove edx-e2e-tests from the Open edX release process.

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,4 +3,3 @@
 
 oeps:
     oep-18: true
-openedx-release: {ref: master}


### PR DESCRIPTION
This repo is a legacy way of testing the Open edX LMS and CMS.  It's fairly specific to the edx.org deployment and Open edX has a different set of tests that it runs on named releases.

Given these two things, stop tagging this repo as a part of Open edX Named Releases.